### PR TITLE
ENH: new date-based versioning; `qiime` -> `qiime2` package rename

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,13 @@ before_install:
   - ./miniconda.sh -b
   - export PATH=/home/travis/miniconda3/bin:$PATH
 install:
-  - conda create --yes -n test-env python=$PYTHON_VERSION nose numpy flake8
+  - conda create --yes -n test-env python=$PYTHON_VERSION nose numpy
   - source activate test-env
   - pip install https://github.com/qiime2/qiime2/archive/master.zip https://github.com/qiime2/q2-types/archive/master.zip https://github.com/qiime2/q2templates/archive/master.zip
+  - pip install flake8
   - pip install .
+  - git clone https://github.com/qiime2/q2lint
 script:
   - nosetests
-  - flake8 q2_feature_table setup.py
+  - flake8
+  - python q2lint/q2lint.py

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,6 @@
-Copyright (c) 2016, QIIME 2 Development Team
+BSD 3-Clause License
+
+Copyright (c) 2016-2017, QIIME 2 development team.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -11,7 +13,7 @@ modification, are permitted provided that the following conditions are met:
   this list of conditions and the following disclaimer in the documentation
   and/or other materials provided with the distribution.
 
-* Neither the name of q2-feature-table nor the names of its
+* Neither the name of the copyright holder nor the names of its
   contributors may be used to endorse or promote products derived from
   this software without specific prior written permission.
 

--- a/q2_feature_table/__init__.py
+++ b/q2_feature_table/__init__.py
@@ -1,10 +1,12 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
+
+import pkg_resources
 
 from ._normalize import rarefy
 from ._transform import (presence_absence, relative_frequency)
@@ -13,7 +15,7 @@ from ._merge import (merge, merge_seq_data, merge_taxa_data)
 from ._filter import (filter_samples, filter_features)
 
 
-__version__ = '0.0.7.dev0'
+__version__ = pkg_resources.get_distribution('q2-feature-table').version
 
 __all__ = ['rarefy', 'presence_absence', 'relative_frequency', 'summarize',
            'merge', 'merge_seq_data', 'filter_samples', 'filter_features',

--- a/q2_feature_table/_filter.py
+++ b/q2_feature_table/_filter.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -9,7 +9,7 @@
 import sqlite3
 
 import biom
-import qiime
+import qiime2
 import numpy as np
 
 
@@ -104,7 +104,7 @@ def _filter(table, min_frequency, max_frequency, min_nonzero, max_nonzero,
 def filter_samples(table: biom.Table, min_frequency: int=0,
                    max_frequency: int=None, min_features: int=0,
                    max_features: int=None,
-                   sample_metadata: qiime.Metadata=None, where: str=None)\
+                   sample_metadata: qiime2.Metadata=None, where: str=None)\
                   -> biom.Table:
     _filter(table=table, min_frequency=min_frequency,
             max_frequency=max_frequency, min_nonzero=min_features,
@@ -117,7 +117,7 @@ def filter_samples(table: biom.Table, min_frequency: int=0,
 def filter_features(table: biom.Table, min_frequency: int=0,
                     max_frequency: int=None, min_samples: int=0,
                     max_samples: int=None,
-                    feature_metadata: qiime.Metadata=None, where: str=None)\
+                    feature_metadata: qiime2.Metadata=None, where: str=None)\
                    -> biom.Table:
     _filter(table=table, min_frequency=min_frequency,
             max_frequency=max_frequency, min_nonzero=min_samples,

--- a/q2_feature_table/_merge.py
+++ b/q2_feature_table/_merge.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_feature_table/_normalize.py
+++ b/q2_feature_table/_normalize.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_feature_table/_summarize/__init__.py
+++ b/q2_feature_table/_summarize/__init__.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_feature_table/_summarize/_visualizer.py
+++ b/q2_feature_table/_summarize/_visualizer.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_feature_table/_transform.py
+++ b/q2_feature_table/_transform.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_feature_table/plugin_setup.py
+++ b/q2_feature_table/plugin_setup.py
@@ -1,13 +1,13 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
-import qiime
-from qiime.plugin import Plugin, Int, Properties, Metadata, Str
+import qiime2
+from qiime2.plugin import Plugin, Int, Properties, Metadata, Str
 
 import q2_feature_table
 from q2_types.feature_table import (
@@ -112,7 +112,7 @@ plugin.methods.register_function(
 _where_description = ("The where parameter takes a SQLite WHERE clause. "
                       "See the table filtering tutorial for additional "
                       "detail: https://docs.qiime2.org/%s/tutorials/"
-                      "table-filtering.html" % qiime.__version__)
+                      "table-filtering.html" % qiime2.__version__)
 
 plugin.methods.register_function(
     function=q2_feature_table.filter_samples,

--- a/q2_feature_table/tests/__init__.py
+++ b/q2_feature_table/tests/__init__.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_feature_table/tests/test_filter.py
+++ b/q2_feature_table/tests/test_filter.py
@@ -1,13 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file LICENSE, distributed with this software.
-# ----------------------------------------------------------------------------
-
-# ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -16,7 +8,7 @@
 
 import unittest
 
-import qiime
+import qiime2
 import numpy as np
 import pandas as pd
 from biom.table import Table
@@ -31,7 +23,7 @@ class IdsWhereTests(unittest.TestCase):
         df = pd.DataFrame({'Subject': ['subject-1', 'subject-1', 'subject-2'],
                            'SampleType': ['gut', 'tongue', 'gut']},
                           index=['S1', 'S2', 'S3'])
-        metadata = qiime.Metadata(df)
+        metadata = qiime2.Metadata(df)
 
         where = "Subject='subject-1' AND SampleType="
         with self.assertRaises(ValueError):
@@ -45,7 +37,7 @@ class IdsWhereTests(unittest.TestCase):
         df = pd.DataFrame({'Subject': ['subject-1', 'subject-1', 'subject-2'],
                            'SampleType': ['gut', 'tongue', 'gut']},
                           index=['S1', 'S2', 'S3'])
-        metadata = qiime.Metadata(df)
+        metadata = qiime2.Metadata(df)
 
         where = "not-a-column-name='subject-1'"
         with self.assertRaises(ValueError):
@@ -55,7 +47,7 @@ class IdsWhereTests(unittest.TestCase):
         df = pd.DataFrame({'Subject': ['subject-1', 'subject-1', 'subject-2'],
                            'SampleType': ['gut', 'tongue', 'gut']},
                           index=pd.Index(['S1', 'S2', 'S3'], name='id'))
-        metadata = qiime.Metadata(df)
+        metadata = qiime2.Metadata(df)
 
         where = "Subject='subject-3'"
         actual = _ids_where(metadata, where)
@@ -66,7 +58,7 @@ class IdsWhereTests(unittest.TestCase):
         df = pd.DataFrame({'Subject': ['subject-1', 'subject-1', 'subject-2'],
                            'SampleType': ['gut', 'tongue', 'gut']},
                           index=pd.Index(['S1', 'S2', 'S3'], name='id'))
-        metadata = qiime.Metadata(df)
+        metadata = qiime2.Metadata(df)
 
         where = "Subject='subject-1'"
         actual = _ids_where(metadata, where)
@@ -97,7 +89,7 @@ class IdsWhereTests(unittest.TestCase):
         df = pd.DataFrame({'Subject': ['subject-1', 'subject-1', 'subject-2'],
                            'SampleType': ['gut', 'tongue', 'gut']},
                           index=pd.Index(['S1', 'S2', 'S3'], name='id'))
-        metadata = qiime.Metadata(df)
+        metadata = qiime2.Metadata(df)
 
         where = "Subject='subject-1' OR Subject='subject-2'"
         actual = _ids_where(metadata, where)
@@ -268,7 +260,7 @@ class FilterSamplesTests(unittest.TestCase):
         df = pd.DataFrame({'Subject': ['subject-1', 'subject-1', 'subject-2'],
                            'SampleType': ['gut', 'tongue', 'gut']},
                           index=['S1', 'S2', 'S3'])
-        metadata = qiime.Metadata(df)
+        metadata = qiime2.Metadata(df)
         table = Table(np.array([[0, 1, 3], [1, 1, 2]]),
                       ['O1', 'O2'],
                       ['S1', 'S2', 'S3'])
@@ -282,7 +274,7 @@ class FilterSamplesTests(unittest.TestCase):
         df = pd.DataFrame({'Subject': ['subject-1', 'subject-2'],
                            'SampleType': ['tongue', 'gut']},
                           index=['S2', 'S3'])
-        metadata = qiime.Metadata(df)
+        metadata = qiime2.Metadata(df)
         table = Table(np.array([[0, 1, 3], [1, 1, 2]]),
                       ['O1', 'O2'],
                       ['S1', 'S2', 'S3'])
@@ -294,7 +286,7 @@ class FilterSamplesTests(unittest.TestCase):
 
         # filter all
         df = pd.DataFrame({})
-        metadata = qiime.Metadata(df)
+        metadata = qiime2.Metadata(df)
         table = Table(np.array([[0, 1, 3], [1, 1, 2]]),
                       ['O1', 'O2'],
                       ['S1', 'S2', 'S3'])
@@ -306,7 +298,7 @@ class FilterSamplesTests(unittest.TestCase):
         df = pd.DataFrame({'Subject': ['subject-1', 'subject-1', 'subject-2'],
                            'SampleType': ['gut', 'tongue', 'gut']},
                           index=['S-not-in-table', 'S2', 'S3'])
-        metadata = qiime.Metadata(df)
+        metadata = qiime2.Metadata(df)
         table = Table(np.array([[0, 1, 3], [1, 1, 2]]),
                       ['O1', 'O2'],
                       ['S1', 'S2', 'S3'])
@@ -321,7 +313,7 @@ class FilterSamplesTests(unittest.TestCase):
         df = pd.DataFrame({'Subject': ['subject-1', 'subject-1', 'subject-2'],
                            'SampleType': ['gut', 'tongue', 'gut']},
                           index=pd.Index(['S1', 'S2', 'S3'], name='#SampleID'))
-        metadata = qiime.Metadata(df)
+        metadata = qiime2.Metadata(df)
         table = Table(np.array([[0, 1, 3], [1, 1, 2]]),
                       ['O1', 'O2'],
                       ['S1', 'S2', 'S3'])
@@ -336,7 +328,7 @@ class FilterSamplesTests(unittest.TestCase):
         df = pd.DataFrame({'Subject': ['subject-1', 'subject-1', 'subject-2'],
                            'SampleType': ['gut', 'tongue', 'gut']},
                           index=pd.Index(['S1', 'S2', 'S3'], name='#SampleID'))
-        metadata = qiime.Metadata(df)
+        metadata = qiime2.Metadata(df)
         table = Table(np.array([[0, 1, 3], [1, 1, 2]]),
                       ['O1', 'O2'],
                       ['S1', 'S2', 'S3'])
@@ -351,7 +343,7 @@ class FilterSamplesTests(unittest.TestCase):
         df = pd.DataFrame({'Subject': ['subject-1', 'subject-1', 'subject-2'],
                            'SampleType': ['gut', 'tongue', 'gut']},
                           index=pd.Index(['S1', 'S2', 'S3'], name='#SampleID'))
-        metadata = qiime.Metadata(df)
+        metadata = qiime2.Metadata(df)
         table = Table(np.array([[0, 1, 3], [1, 1, 2]]),
                       ['O1', 'O2'],
                       ['S1', 'S2', 'S3'])
@@ -366,7 +358,7 @@ class FilterSamplesTests(unittest.TestCase):
         df = pd.DataFrame({'Subject': ['subject-1', 'subject-1', 'subject-2'],
                            'SampleType': ['gut', 'tongue', 'gut']},
                           index=pd.Index(['S1', 'S2', 'S3'], name='#SampleID'))
-        metadata = qiime.Metadata(df)
+        metadata = qiime2.Metadata(df)
         table = Table(np.array([[0, 1, 3], [1, 1, 2]]),
                       ['O1', 'O2'],
                       ['S1', 'S2', 'S3'])
@@ -380,7 +372,7 @@ class FilterSamplesTests(unittest.TestCase):
         df = pd.DataFrame({'Subject': ['subject-1', 'subject-1', 'subject-2'],
                            'SampleType': ['gut', 'tongue', 'gut']},
                           index=pd.Index(['S1', 'S2', 'S3'], name='#SampleID'))
-        metadata = qiime.Metadata(df)
+        metadata = qiime2.Metadata(df)
         table = Table(np.array([[0, 1, 3], [1, 1, 2]]),
                       ['O1', 'O2'],
                       ['S1', 'S2', 'S3'])
@@ -396,7 +388,7 @@ class FilterSamplesTests(unittest.TestCase):
         df = pd.DataFrame({'Subject': ['subject-1', 'subject-1', 'subject-2'],
                            'SampleType': ['gut', 'tongue', 'gut']},
                           index=pd.Index(['S1', 'S2', 'S3'], name='#SampleID'))
-        metadata = qiime.Metadata(df)
+        metadata = qiime2.Metadata(df)
         table = Table(np.array([[0, 1, 3], [1, 1, 2]]),
                       ['O1', 'O2'],
                       ['S1', 'S2', 'S3'])
@@ -481,7 +473,7 @@ class FilterFeaturesTests(unittest.TestCase):
         # no filtering
         df = pd.DataFrame({'SequencedGenome': ['yes', 'yes']},
                           index=['O1', 'O2'])
-        metadata = qiime.Metadata(df)
+        metadata = qiime2.Metadata(df)
         table = Table(np.array([[0, 1, 3], [1, 1, 2]]),
                       ['O1', 'O2'],
                       ['S1', 'S2', 'S3'])
@@ -494,7 +486,7 @@ class FilterFeaturesTests(unittest.TestCase):
         # filter one
         df = pd.DataFrame({'SequencedGenome': ['yes']},
                           index=['O1'])
-        metadata = qiime.Metadata(df)
+        metadata = qiime2.Metadata(df)
         table = Table(np.array([[0, 1, 3], [1, 1, 2]]),
                       ['O1', 'O2'],
                       ['S1', 'S2', 'S3'])
@@ -506,7 +498,7 @@ class FilterFeaturesTests(unittest.TestCase):
 
         # filter all
         df = pd.DataFrame({})
-        metadata = qiime.Metadata(df)
+        metadata = qiime2.Metadata(df)
         table = Table(np.array([[0, 1, 3], [1, 1, 2]]),
                       ['O1', 'O2'],
                       ['S1', 'S2', 'S3'])
@@ -518,7 +510,7 @@ class FilterFeaturesTests(unittest.TestCase):
         # no filtering
         df = pd.DataFrame({'SequencedGenome': ['yes', 'no']},
                           index=pd.Index(['O1', 'O2'], name='feature-id'))
-        metadata = qiime.Metadata(df)
+        metadata = qiime2.Metadata(df)
         table = Table(np.array([[0, 1, 3], [1, 1, 2]]),
                       ['O1', 'O2'],
                       ['S1', 'S2', 'S3'])
@@ -532,7 +524,7 @@ class FilterFeaturesTests(unittest.TestCase):
         # filter one
         df = pd.DataFrame({'SequencedGenome': ['yes', 'no']},
                           index=pd.Index(['O1', 'O2'], name='feature-id'))
-        metadata = qiime.Metadata(df)
+        metadata = qiime2.Metadata(df)
         table = Table(np.array([[0, 1, 3], [1, 1, 2]]),
                       ['O1', 'O2'],
                       ['S1', 'S2', 'S3'])
@@ -546,7 +538,7 @@ class FilterFeaturesTests(unittest.TestCase):
         # filter all
         df = pd.DataFrame({'SequencedGenome': ['yes', 'no']},
                           index=pd.Index(['O1', 'O2'], name='feature-id'))
-        metadata = qiime.Metadata(df)
+        metadata = qiime2.Metadata(df)
         table = Table(np.array([[0, 1, 3], [1, 1, 2]]),
                       ['O1', 'O2'],
                       ['S1', 'S2', 'S3'])
@@ -554,6 +546,7 @@ class FilterFeaturesTests(unittest.TestCase):
         actual = filter_features(table, feature_metadata=metadata, where=where)
         expected = Table(np.array([]), [], [])
         self.assertEqual(actual, expected)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/q2_feature_table/tests/test_merge.py
+++ b/q2_feature_table/tests/test_merge.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -122,6 +122,7 @@ class MergeFeatureTaxonomyTests(unittest.TestCase):
         exp = pd.Series(['a;b;c;d', 'a;b;c;e', 'a;b;c;e'],
                         index=['f1', 'f2', 'f3'])
         pdt.assert_series_equal(obs, exp)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/q2_feature_table/tests/test_normalize.py
+++ b/q2_feature_table/tests/test_normalize.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -26,6 +26,7 @@ class RarefyTests(TestCase):
         self.assertEqual(set(a.ids(axis='sample')), set(['S2', 'S3']))
         self.assertEqual(set(a.ids(axis='observation')), set(['O1', 'O2']))
         npt.assert_array_equal(a.sum(axis='sample'), np.array([2., 2.]))
+
 
 if __name__ == "__main__":
     main()

--- a/q2_feature_table/tests/test_summarize.py
+++ b/q2_feature_table/tests/test_summarize.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -7,16 +7,16 @@
 # ----------------------------------------------------------------------------
 
 import os
-import unittest
+from unittest import TestCase, main
 import tempfile
 
 import skbio
-from q2_types import DNAIterator
+from q2_types.feature_data import DNAIterator
 
 from q2_feature_table import tabulate_seqs
 
 
-class TabulateSeqsTests(unittest.TestCase):
+class TabulateSeqsTests(TestCase):
 
     def test_basic(self):
         seqs = DNAIterator(
@@ -30,3 +30,7 @@ class TabulateSeqsTests(unittest.TestCase):
             self.assertTrue(os.path.exists(expected_fp))
             self.assertTrue('ACGT</a>' in open(expected_fp).read())
             self.assertTrue('<td>seq2</td>' in open(expected_fp).read())
+
+
+if __name__ == "__main__":
+    main()

--- a/q2_feature_table/tests/test_transform.py
+++ b/q2_feature_table/tests/test_transform.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -42,6 +42,7 @@ class PresenceAbsenceTests(TestCase):
         self.assertEqual(set(a.ids(axis='observation')), set(['O1', 'O2']))
         npt.assert_array_equal(a.matrix_data.toarray(),
                                np.array([[0, 1, 1], [1, 1, 1]]))
+
 
 if __name__ == "__main__":
     main()

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -10,12 +10,11 @@ from setuptools import setup, find_packages
 
 setup(
     name="q2-feature-table",
-    # TODO stop duplicating version string
-    version='0.0.7.dev0',
+    version='2017.2.0.dev0',
     packages=find_packages(),
-    install_requires=['qiime >= 2.0.6', 'q2-types >= 0.0.6',
-                      'biom-format >= 2.1.5, < 2.2.0', 'seaborn',
-                      'scikit-bio', 'q2templates >= 0.0.6', 'numpy'],
+    install_requires=['qiime2 == 2017.2.*', 'q2-types == 2017.2.*',
+                      'q2templates == 2017.2.*', 'seaborn', 'numpy',
+                      'biom-format >= 2.1.5, < 2.2.0', 'scikit-bio'],
     package_data={'q2_feature_table': ['workflows/*md'],
                   'q2_feature_table._summarize': [
                         'summarize_assets/*.html',
@@ -25,9 +24,9 @@ setup(
     author_email="gregcaporaso@gmail.com",
     description="Functionality for working with sample by feature tables.",
     license='BSD-3-Clause',
-    url="http://www.qiime.org",
+    url="https://qiime2.org",
     entry_points={
-        'qiime.plugins':
+        'qiime2.plugins':
         ['q2-feature-table=q2_feature_table.plugin_setup:plugin']
     }
 )


### PR DESCRIPTION
# ~~DO NOT MERGE~~

New date-based versioning scheme is:

- YYYY.M.patch.dev0 for development version (e.g. 2017.2.0.dev0, 2017.2.1.dev0, 2018.10.0.dev0)
- YYYY.M.patch for release version (e.g. 2017.2.0, 2017.2.1, 2018.10.0)

Plugins/interfaces are recommended to specify `qiime2 == YYYY.M.*` in setup.py's `install_requires` to obtain patch releases for a given train release.

The new versioning scheme is PEP 440 compliant.