### PR TITLE
Multi-commit Summarize Improvements

### DIFF
--- a/q2_feature_table/_summarize/_visualizer.py
+++ b/q2_feature_table/_summarize/_visualizer.py
@@ -92,16 +92,24 @@ def summarize(output_dir: str, table: biom.Table) -> None:
     }
 
     sample_frequencies.sort_values(inplace=True)
+    feature_frequencies.sort_values(inplace=True)
     sample_frequencies.to_csv(
         os.path.join(output_dir, 'sample-frequency-detail.csv'))
+    feature_frequencies.to_csv(
+        os.path.join(output_dir, 'feature-frequency-detail.csv'))
 
     sample_frequencies_table = _format_html_table(
         sample_frequencies.to_frame('Frequency'))
+    feature_frequencies_table = _format_html_table(
+        feature_frequencies.to_frame('Frequency'))
     sample_frequency_template = os.path.join(
         TEMPLATES, 'summarize_assets', 'sample-frequency-detail.html')
+    feature_frequency_template = os.path.join(
+        TEMPLATES, 'summarize_assets', 'feature-frequency-detail.html')
 
-    context.update({'sample_frequencies_table': sample_frequencies_table})
-    templates = [index, sample_frequency_template]
+    context.update({'sample_frequencies_table': sample_frequencies_table,
+                    'feature_frequencies_table': feature_frequencies_table})
+    templates = [index, sample_frequency_template, feature_frequency_template]
     q2templates.render(templates, output_dir, context=context)
 
 

--- a/q2_feature_table/_summarize/_visualizer.py
+++ b/q2_feature_table/_summarize/_visualizer.py
@@ -14,6 +14,7 @@ import biom
 import numpy as np
 import pandas as pd
 import seaborn as sns
+import matplotlib
 import matplotlib.pyplot as plt
 from q2_types.feature_data import DNAIterator
 import q2templates
@@ -54,6 +55,8 @@ def summarize(output_dir: str, table: biom.Table) -> None:
     if number_of_samples > 1:
         sample_frequencies_ax = sns.distplot(sample_frequencies, kde=False,
                                              rug=True)
+        sample_frequencies_ax.get_xaxis().set_major_formatter(
+            matplotlib.ticker.FuncFormatter(lambda x, p: format(int(x), ',')))
         sample_frequencies_ax.set_xlabel('Frequency per sample')
         sample_frequencies_ax.get_figure().savefig(
             os.path.join(output_dir, 'sample-frequencies.pdf'))
@@ -75,9 +78,9 @@ def summarize(output_dir: str, table: biom.Table) -> None:
             os.path.join(output_dir, 'feature-frequencies.png'))
 
     sample_summary_table = _format_html_table(
-        sample_summary.to_frame('Frequency'))
+        sample_summary.apply('{:,}'.format).to_frame('Frequency'))
     feature_summary_table = _format_html_table(
-        feature_summary.to_frame('Frequency'))
+        feature_summary.apply('{:,}'.format).to_frame('Frequency'))
 
     index = os.path.join(TEMPLATES, 'summarize_assets', 'index.html')
     context = {

--- a/q2_feature_table/_summarize/_visualizer.py
+++ b/q2_feature_table/_summarize/_visualizer.py
@@ -119,9 +119,11 @@ def _frequency_summary(table, axis='sample'):
 
     summary = pd.Series([frequencies.min(), frequencies.quantile(0.25),
                          frequencies.median(), frequencies.quantile(0.75),
-                         frequencies.max(), frequencies.mean()],
+                         frequencies.max()],
                         index=['Minimum frequency', '1st quartile',
                                'Median frequency', '3rd quartile',
-                               'Maximum frequency', 'Mean frequency'])
-    summary.sort_values()
+                               'Maximum frequency'])
+    mean = pd.Series([frequencies.mean()], index=['Mean frequency'])
+    summary.sort_values(ascending=False, inplace=True)
+    summary = mean.append(summary)
     return summary, frequencies

--- a/q2_feature_table/_summarize/_visualizer.py
+++ b/q2_feature_table/_summarize/_visualizer.py
@@ -53,8 +53,16 @@ def summarize(output_dir: str, table: biom.Table) -> None:
     sample_summary, sample_frequencies = _frequency_summary(
         table, axis='sample')
     if number_of_samples > 1:
+        # Freedman–Diaconis rule
+        IQR = sample_summary['3rd quartile'] - sample_summary['1st quartile']
+        bin_width = (2 * IQR) / (number_of_samples ** (1/3))
+
+        # Calculate the bin count, with a minimum of 5 bins
+        bins = max((sample_summary['Maximum frequency'] -
+                    sample_summary['Minimum frequency']) / bin_width + 1, 5)
+
         sample_frequencies_ax = sns.distplot(sample_frequencies, kde=False,
-                                             rug=True)
+                                             rug=True, bins=round(bins))
         sample_frequencies_ax.get_xaxis().set_major_formatter(
             matplotlib.ticker.FuncFormatter(lambda x, p: format(int(x), ',')))
         sample_frequencies_ax.set_xlabel('Frequency per sample')

--- a/q2_feature_table/_summarize/_visualizer.py
+++ b/q2_feature_table/_summarize/_visualizer.py
@@ -59,7 +59,7 @@ def summarize(output_dir: str, table: biom.Table) -> None:
 
         # Calculate the bin count, with a minimum of 5 bins
         bins = max((sample_summary['Maximum frequency'] -
-                    sample_summary['Minimum frequency']) / bin_width + 1, 5)
+                    sample_summary['Minimum frequency']) / bin_width, 5)
 
         sample_frequencies_ax = sns.distplot(sample_frequencies, kde=False,
                                              rug=True, bins=round(bins))
@@ -99,8 +99,8 @@ def summarize(output_dir: str, table: biom.Table) -> None:
         'feature_summary_table': feature_summary_table,
     }
 
-    sample_frequencies.sort_values(inplace=True)
-    feature_frequencies.sort_values(inplace=True)
+    sample_frequencies.sort_values(inplace=True, ascending=False)
+    feature_frequencies.sort_values(inplace=True, ascending=False)
     sample_frequencies.to_csv(
         os.path.join(output_dir, 'sample-frequency-detail.csv'))
     feature_frequencies.to_csv(
@@ -135,11 +135,8 @@ def _frequency_summary(table, axis='sample'):
 
     summary = pd.Series([frequencies.min(), frequencies.quantile(0.25),
                          frequencies.median(), frequencies.quantile(0.75),
-                         frequencies.max()],
+                         frequencies.max(), frequencies.mean()],
                         index=['Minimum frequency', '1st quartile',
                                'Median frequency', '3rd quartile',
-                               'Maximum frequency'])
-    mean = pd.Series([frequencies.mean()], index=['Mean frequency'])
-    summary.sort_values(ascending=False, inplace=True)
-    summary = mean.append(summary)
+                               'Maximum frequency', 'Mean frequency'])
     return summary, frequencies

--- a/q2_feature_table/_summarize/summarize_assets/feature-frequency-detail.html
+++ b/q2_feature_table/_summarize/summarize_assets/feature-frequency-detail.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+
+{% block content %}
+  <div class="row">
+    <div class="col-lg-12">
+      {{ feature_frequencies_table }}
+    </div>
+  </div>
+{% endblock %}

--- a/q2_feature_table/_summarize/summarize_assets/index.html
+++ b/q2_feature_table/_summarize/summarize_assets/index.html
@@ -17,15 +17,15 @@
             <tbody>
               <tr>
                 <th scope="row">Number of samples</th>
-                <td>{{ number_of_samples }}</td>
+                <td>{{ "{:,}".format(number_of_samples) }}</td>
               </tr>
               <tr>
                 <th scope="row">Number of features</th>
-                <td>{{ number_of_features }}</td>
+                <td>{{ "{:,}".format(number_of_features) }}</td>
               </tr>
               <tr>
                 <th scope="row">Total frequency</th>
-                <td>{{ total_frequencies }}</td>
+                <td>{{ "{:,}".format(total_frequencies) }}</td>
               </tr>
             </tbody>
           </table>

--- a/q2_feature_table/_summarize/summarize_assets/index.html
+++ b/q2_feature_table/_summarize/summarize_assets/index.html
@@ -58,8 +58,11 @@
       <div class="row">
         <div class="col-lg-6">
           <h1>Frequency per feature</h1>
-
           {{ feature_summary_table }}
+          <p class="text-left">
+            Frequency per feature detail (<a href="feature-frequency-detail.csv">csv</a> |
+            <a href="feature-frequency-detail.html">html</a>)
+          </p>
         </div>
         {% if number_of_features > 1 %}
         <div class="col-lg-6">

--- a/q2_feature_table/_summarize/summarize_assets/index.html
+++ b/q2_feature_table/_summarize/summarize_assets/index.html
@@ -56,13 +56,13 @@
       </div>
 
       <div class="row">
-        <div class="col-md-6">
+        <div class="col-lg-6">
           <h1>Frequency per feature</h1>
 
           {{ feature_summary_table }}
         </div>
         {% if number_of_features > 1 %}
-        <div class="col-md-6">
+        <div class="col-lg-6">
           <p class="text-center">
               <a href="feature-frequencies.pdf">
                   <img src="feature-frequencies.png" width="700" height="500" class="center-block">


### PR DESCRIPTION
- [x] add thousands separator (e.g., '{:,}'.format(1234567890), maybe think about internationalization here...)
- [x] add frequency per feature tables
- [x] reverse sort frequency per sample and frequency per feature tables, so highest frequencies are on top
- [x] the width of the bars in the sample/feature count plots are confusing to users (they can't really tell that this is a histogram) when there are few samples. we should make the bin size smaller. for example:

<img width="632" alt="screenshot 2016-10-12 03 07 10" src="https://cloud.githubusercontent.com/assets/192372/19306151/23bd2e4a-9029-11e6-8175-2233f1974af7.png">

- ~interactive exploration of rarefaction depth, as we had in q2d2. this would be really helpful to integrate with metadata, so you can determine how many samples of each metadata type a specific depth would filter from your data set~
- ~some users at the iceland workshop noted that it would be useful to know the taxonomic composition of the samples when they're choosing their even sampling depth based on the `summarize` output - this should be possible, but would require optional artifacts and would have some overlap with the existing taxa plots (so this is lower priority)~


Resolves #24