### PR TITLE
MAINT: remove filtering tutorial url from help text

### DIFF
--- a/q2_feature_table/plugin_setup.py
+++ b/q2_feature_table/plugin_setup.py
@@ -6,7 +6,6 @@
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
-import qiime2
 from qiime2.plugin import Plugin, Int, Properties, Metadata, Str
 
 import q2_feature_table
@@ -203,9 +202,7 @@ plugin.methods.register_function(
     description="Filter samples from table based on frequency and/or "
                 "metadata. Any features with a frequency of zero after sample "
                 "filtering will also be removed. See the filtering tutorial "
-                "for additional details: "
-                "https://docs.qiime2.org/%s/tutorials/filtering/" %
-                qiime2.__version__
+                "on https://docs.qiime2.org for additional details."
 )
 
 plugin.methods.register_function(
@@ -248,9 +245,7 @@ plugin.methods.register_function(
     description="Filter features from table based on frequency and/or "
                 "metadata. Any samples with a frequency of zero after feature "
                 "filtering will also be removed. See the filtering tutorial "
-                "for additional details: "
-                "https://docs.qiime2.org/%s/tutorials/filtering/" %
-                qiime2.__version__
+                "on https://docs.qiime2.org for additional details."
 )
 
 plugin.visualizers.register_function(


### PR DESCRIPTION
URLs are changing quite a bit between QIIME 2 releases. It's better to link to the docs site and describe what tutorial users need to look for, instead of having a broken link in the software that requires a patch release to fix. We can re-introduce specific URLs to the software when URLs are more stable/predictable.