### PR TITLE
TST: adds coverage testing and reporting to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,15 @@ before_install:
   - ./miniconda.sh -b
   - export PATH=/home/travis/miniconda3/bin:$PATH
 install:
-  - conda create --yes -n test-env python=$PYTHON_VERSION nose numpy ipywidgets
+  - conda create --yes -n test-env python=$PYTHON_VERSION numpy ipywidgets pytest pytest-cov
   - source activate test-env
   - pip install https://github.com/qiime2/qiime2/archive/master.zip https://github.com/qiime2/q2-types/archive/master.zip https://github.com/qiime2/q2templates/archive/master.zip
-  - pip install flake8
+  - pip install flake8 coveralls
   - pip install .
   - git clone https://github.com/qiime2/q2lint
 script:
-  - nosetests
+  - py.test --cov=q2_feature_table
   - flake8
   - python q2lint/q2lint.py
+after_success:
+  - coveralls

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # feature table
 
-Official QIIME 2 plugin supporting basic operations on sample x feature
-tables.
+[![Build Status](https://travis-ci.org/qiime2/q2-feature-table.svg?branch=master)](https://travis-ci.org/qiime2/q2-feature-table)
+[![Coverage Status](https://coveralls.io/repos/github/qiime2/q2-feature-table/badge.svg)](https://coveralls.io/github/qiime2/q2-feature-table)
 
 This is a QIIME 2 plugin. For details on QIIME 2, see https://qiime2.org.


### PR DESCRIPTION
* Adds test coverage reporting (see [here](https://coveralls.io/builds/10282745/source?filename=q2_feature_table%2F_summarize%2F_visualizer.py), for example). 
* Swaps `py.test` for `nosetests` as the former integrates more easily with `Coverage.py`, and is a drop-in replacement for how we were using `nosetests`.
* Adds coveralls badge to `README.md`. 

This PR serves as a proposal for how I'll update the other QIIME2 repos to include coverage reporting. Once we're good with how this is happening, I'll start working on other PRs. 