### PR TITLE
ENH: Clarify error message when table is rarefied to nothing

### DIFF
--- a/q2_feature_table/_normalize.py
+++ b/q2_feature_table/_normalize.py
@@ -10,4 +10,11 @@ import biom
 
 
 def rarefy(table: biom.Table, sampling_depth: int) -> biom.Table:
-    return table.subsample(sampling_depth, axis='sample', by_id=False)
+    table = table.subsample(sampling_depth, axis='sample', by_id=False)
+
+    if table.is_empty():
+        raise ValueError('The rarefied table contains no samples or features. '
+                         'Verify your table is valid and that you provided a '
+                         'shallow enough sampling depth.')
+
+    return table

--- a/q2_feature_table/tests/test_normalize.py
+++ b/q2_feature_table/tests/test_normalize.py
@@ -27,6 +27,14 @@ class RarefyTests(TestCase):
         self.assertEqual(set(a.ids(axis='observation')), set(['O1', 'O2']))
         npt.assert_array_equal(a.sum(axis='sample'), np.array([2., 2.]))
 
+    def test_rarefy_depth_error(self):
+        t = Table(np.array([[0, 1, 3], [1, 1, 2]]),
+                  ['O1', 'O2'],
+                  ['S1', 'S2', 'S3'])
+
+        with self.assertRaisesRegex(ValueError, 'shallow enough'):
+            rarefy(t, 50)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Addresses part of #87 

![image](https://cloud.githubusercontent.com/assets/2638727/25683930/60d64066-3013-11e7-843d-8a1faa7a86f1.png)
