### PR TITLE
MAINT: avoid empty Metadata in unit tests

### DIFF
--- a/q2_feature_table/tests/test_filter.py
+++ b/q2_feature_table/tests/test_filter.py
@@ -194,7 +194,7 @@ class FilterSamplesTests(unittest.TestCase):
         self.assertEqual(actual, expected)
 
         # filter all
-        df = pd.DataFrame({})
+        df = pd.DataFrame({}, index=['foo'])
         metadata = qiime2.Metadata(df)
         table = Table(np.array([[0, 1, 3], [1, 1, 2]]),
                       ['O1', 'O2'],
@@ -406,7 +406,7 @@ class FilterFeaturesTests(unittest.TestCase):
         self.assertEqual(actual, expected)
 
         # filter all
-        df = pd.DataFrame({})
+        df = pd.DataFrame({}, index=['foo'])
         metadata = qiime2.Metadata(df)
         table = Table(np.array([[0, 1, 3], [1, 1, 2]]),
                       ['O1', 'O2'],


### PR DESCRIPTION
Necessary for changes in https://github.com/qiime2/qiime2/pull/277