### PR TITLE
ENH: Optional flag for exclusion filters, Fixes #101

### DIFF
--- a/q2_feature_table/_filter.py
+++ b/q2_feature_table/_filter.py
@@ -41,10 +41,6 @@ def _filter(table, min_frequency, max_frequency, min_nonzero, max_nonzero,
     if metadata is None and exclude_ids is True:
         raise ValueError("Metadata must be provided if 'exclude_ids' "
                          "is true.")
-    if where is not None and exclude_ids is True:
-        raise ValueError("'exclude_ids' must be false if 'where' is "
-                         "specified.")
-
     if metadata is not None:
         ids_to_keep = metadata.ids(where=where)
     else:

--- a/q2_feature_table/_filter.py
+++ b/q2_feature_table/_filter.py
@@ -13,6 +13,7 @@ import numpy as np
 
 def _get_biom_filter_function(ids_to_keep, min_frequency, max_frequency,
                               min_nonzero, max_nonzero):
+    ids_to_keep = set(ids_to_keep)
     if max_frequency is None:
         max_frequency = np.inf
     if max_nonzero is None:
@@ -31,14 +32,18 @@ _other_axis_map = {'sample': 'observation', 'observation': 'sample'}
 def _filter(table, min_frequency, max_frequency, min_nonzero, max_nonzero,
             metadata, where, axis, exclude_ids=False):
     if min_frequency == 0 and max_frequency is None and min_nonzero == 0 and\
-       max_nonzero is None and metadata is None and where is None:
+       max_nonzero is None and metadata is None and where is None and\
+       exclude_ids is False:
         raise ValueError("No filtering was requested.")
     if metadata is None and where is not None:
         raise ValueError("Metadata must be provided if 'where' is "
                          "specified.")
     if metadata is None and exclude_ids is True:
         raise ValueError("Metadata must be provided if 'exclude_ids' "
-                         "is specified")
+                         "is true.")
+    if where is not None and exclude_ids is True:
+        raise ValueError("'exclude_ids' must be false if 'where' is "
+                         "specified.")
 
     if metadata is not None:
         ids_to_keep = metadata.ids(where=where)
@@ -46,8 +51,6 @@ def _filter(table, min_frequency, max_frequency, min_nonzero, max_nonzero,
         ids_to_keep = table.ids(axis=axis)
     if exclude_ids is True:
         ids_to_keep = set(table.ids(axis=axis)) - set(ids_to_keep)
-    else:
-        ids_to_keep = set(ids_to_keep)
 
     filter_fn1 = _get_biom_filter_function(
         ids_to_keep, min_frequency, max_frequency, min_nonzero, max_nonzero)

--- a/q2_feature_table/_filter.py
+++ b/q2_feature_table/_filter.py
@@ -40,7 +40,7 @@ def _filter(table, min_frequency, max_frequency, min_nonzero, max_nonzero,
                          "specified.")
     if metadata is None and exclude_ids is True:
         raise ValueError("Metadata must be provided if 'exclude_ids' "
-                         "is true.")
+                         "is True.")
     if metadata is not None:
         ids_to_keep = metadata.ids(where=where)
     else:

--- a/q2_feature_table/plugin_setup.py
+++ b/q2_feature_table/plugin_setup.py
@@ -200,10 +200,9 @@ plugin.methods.register_function(
                  'that must be met to be included in the filtered feature '
                  'table. If not provided, all samples in `metadata` that are '
                  'also in the feature table will be retained.',
-        'exclude_ids': 'If `True`, returns the filtered set of samples '
-                       'which occur in the feature table but not in the '
-                       'metadata (or the filtered metadata, if invoked '
-                       'in conjunction with `where`).'
+        'exclude_ids': 'If `True`, the samples selected by `metadata` or '
+                       '`where` parameters will be excluded from the filtered '
+                       'table instead of being retained.'
     },
     output_descriptions={
         'filtered_table': 'The resulting feature table filtered by sample.'
@@ -249,10 +248,9 @@ plugin.methods.register_function(
                  'that must be met to be included in the filtered feature '
                  'table. If not provided, all features in `metadata` that are '
                  'also in the feature table will be retained.',
-        'exclude_ids': 'If `True`, returns the filtered set of features '
-                       'which occur in the feature table but not in the '
-                       'metadata (or the filtered metadata, if invoked '
-                       'in conjunction with `where`).'
+        'exclude_ids': 'If `True`, the features selected by `metadata` or '
+                       '`where` parameters will be excluded from the filtered '
+                       'table instead of being retained.'
     },
     output_descriptions={
         'filtered_table': 'The resulting feature table filtered by feature.'

--- a/q2_feature_table/plugin_setup.py
+++ b/q2_feature_table/plugin_setup.py
@@ -200,11 +200,10 @@ plugin.methods.register_function(
                  'that must be met to be included in the filtered feature '
                  'table. If not provided, all samples in `metadata` that are '
                  'also in the feature table will be retained.',
-        'exclude_ids': 'If `True`, function returns the filtered set of '
-                       'samples which occur in the feature table but not in '
-                       'the metadata (or not in the metadata which satisfies '
-                       'the `where` parameter, if it is provided). `False` by '
-                       'default.'
+        'exclude_ids': 'If `True`, returns the filtered set of samples '
+                       'which occur in the feature table but not in the '
+                       'metadata (or the filtered metadata, if invoked '
+                       'in conjunction with `where`).'
     },
     output_descriptions={
         'filtered_table': 'The resulting feature table filtered by sample.'
@@ -250,11 +249,10 @@ plugin.methods.register_function(
                  'that must be met to be included in the filtered feature '
                  'table. If not provided, all features in `metadata` that are '
                  'also in the feature table will be retained.',
-        'exclude_ids': 'If `True`, function returns the filtered set of '
-                       'features which occur in the feature table but not in '
-                       'the metadata (or not in the metadata which satisfies '
-                       'the `where` parameter, if it is provided). `False` by '
-                       'default.'
+        'exclude_ids': 'If `True`, returns the filtered set of features '
+                       'which occur in the feature table but not in the '
+                       'metadata (or the filtered metadata, if invoked '
+                       'in conjunction with `where`).'
     },
     output_descriptions={
         'filtered_table': 'The resulting feature table filtered by feature.'

--- a/q2_feature_table/plugin_setup.py
+++ b/q2_feature_table/plugin_setup.py
@@ -6,7 +6,7 @@
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
-from qiime2.plugin import Plugin, Int, Properties, Metadata, Str
+from qiime2.plugin import Plugin, Int, Properties, Metadata, Str, Bool
 
 import q2_feature_table
 from q2_types.feature_table import (
@@ -174,7 +174,8 @@ plugin.methods.register_function(
                 'min_features': Int,
                 'max_features': Int,
                 'metadata': Metadata,
-                'where': Str},
+                'where': Str,
+                'exclude_ids': Bool},
     outputs=[('filtered_table', FeatureTable[Frequency])],
     input_descriptions={
         'table': 'The feature table from which samples should be filtered.'
@@ -197,7 +198,10 @@ plugin.methods.register_function(
         'where': 'SQLite WHERE clause specifying sample metadata criteria '
                  'that must be met to be included in the filtered feature '
                  'table. If not provided, all samples in `metadata` that are '
-                 'also in the feature table will be retained.'
+                 'also in the feature table will be retained.',
+        'exclude_ids': 'If `True`, function returns the filtered set of '
+                       'samples which occur in the feature table but not in '
+                       'the metadata. `False` by default.'
     },
     output_descriptions={
         'filtered_table': 'The resulting feature table filtered by sample.'
@@ -217,7 +221,8 @@ plugin.methods.register_function(
                 'min_samples': Int,
                 'max_samples': Int,
                 'metadata': Metadata,
-                'where': Str},
+                'where': Str,
+                'exclude_ids': Bool},
     outputs=[('filtered_table', FeatureTable[Frequency])],
     input_descriptions={
         'table': 'The feature table from which features should be filtered.'
@@ -240,7 +245,10 @@ plugin.methods.register_function(
         'where': 'SQLite WHERE clause specifying feature metadata criteria '
                  'that must be met to be included in the filtered feature '
                  'table. If not provided, all features in `metadata` that are '
-                 'also in the feature table will be retained.'
+                 'also in the feature table will be retained.',
+        'exclude_ids': 'If `True`, function returns the filtered set of '
+                       'features which occur in the feature table but not in '
+                       'the metadata. `False` by default.'
     },
     output_descriptions={
         'filtered_table': 'The resulting feature table filtered by feature.'

--- a/q2_feature_table/plugin_setup.py
+++ b/q2_feature_table/plugin_setup.py
@@ -243,9 +243,9 @@ plugin.methods.register_function(
                         'be observed in to be retained. If no value is '
                         'provided this will default to infinity (i.e., no '
                         'maximum sample filter will be applied).'),
-        'metadata': 'Sample metadata used with `where` parameter when '
+        'metadata': 'Feature metadata used with `where` parameter when '
                     'selecting features to retain, or with `exclude_ids` '
-                    'when selecting samples to discard.',
+                    'when selecting features to discard.',
         'where': 'SQLite WHERE clause specifying feature metadata criteria '
                  'that must be met to be included in the filtered feature '
                  'table. If not provided, all features in `metadata` that are '

--- a/q2_feature_table/plugin_setup.py
+++ b/q2_feature_table/plugin_setup.py
@@ -202,7 +202,9 @@ plugin.methods.register_function(
                  'also in the feature table will be retained.',
         'exclude_ids': 'If `True`, function returns the filtered set of '
                        'samples which occur in the feature table but not in '
-                       'the metadata. `False` by default.'
+                       'the metadata (or not in the metadata which satisfies '
+                       'the `where` parameter, if it is provided). `False` by '
+                       'default.'
     },
     output_descriptions={
         'filtered_table': 'The resulting feature table filtered by sample.'
@@ -250,7 +252,9 @@ plugin.methods.register_function(
                  'also in the feature table will be retained.',
         'exclude_ids': 'If `True`, function returns the filtered set of '
                        'features which occur in the feature table but not in '
-                       'the metadata. `False` by default.'
+                       'the metadata (or not in the metadata which satisfies '
+                       'the `where` parameter, if it is provided). `False` by '
+                       'default.'
     },
     output_descriptions={
         'filtered_table': 'The resulting feature table filtered by feature.'

--- a/q2_feature_table/plugin_setup.py
+++ b/q2_feature_table/plugin_setup.py
@@ -193,8 +193,9 @@ plugin.methods.register_function(
                          'have to be retained. If no value is provided '
                          'this will default to infinity (i.e., no maximum '
                          'feature filter will be applied).'),
-        'metadata': 'Sample metadata used in conjuction with `where` parameter'
-                    ' to select samples to retain.',
+        'metadata': 'Sample metadata used with `where` parameter when '
+                    'selecting samples to retain, or with `exclude_ids` '
+                    'when selecting samples to discard.',
         'where': 'SQLite WHERE clause specifying sample metadata criteria '
                  'that must be met to be included in the filtered feature '
                  'table. If not provided, all samples in `metadata` that are '
@@ -240,8 +241,9 @@ plugin.methods.register_function(
                         'be observed in to be retained. If no value is '
                         'provided this will default to infinity (i.e., no '
                         'maximum sample filter will be applied).'),
-        'metadata': 'Feature metadata used in conjuction with `where` '
-                    'parameter to select features to retain.',
+        'metadata': 'Sample metadata used with `where` parameter when '
+                    'selecting features to retain, or with `exclude_ids` '
+                    'when selecting samples to discard.',
         'where': 'SQLite WHERE clause specifying feature metadata criteria '
                  'that must be met to be included in the filtered feature '
                  'table. If not provided, all features in `metadata` that are '

--- a/q2_feature_table/tests/test_filter.py
+++ b/q2_feature_table/tests/test_filter.py
@@ -241,6 +241,12 @@ class FilterSamplesTests(unittest.TestCase):
         expected = Table(np.array([]), [], [])
         self.assertEqual(actual, expected)
 
+        # exclude_ids = True, no metadata
+        with self.assertRaisesRegex(ValueError,
+                                    "Metadata must be provided if "
+                                    "'exclude_ids' is true."):
+            filter_samples(table, exclude_ids=True)
+
     def test_sample_metadata_extra_ids(self):
         df = pd.DataFrame({'Subject': ['subject-1', 'subject-1', 'subject-2'],
                            'SampleType': ['gut', 'tongue', 'gut']},
@@ -314,11 +320,6 @@ class FilterSamplesTests(unittest.TestCase):
         expected = Table(np.array([]), [], [])
         self.assertEqual(actual, expected)
 
-        # exclude all and no metadata
-        with self.assertRaises(ValueError):
-            filter_samples(table, metadata=None, where=where,
-                           exclude_ids=True)
-
     def test_combine_id_and_frequency_filters(self):
         # no filtering
         df = pd.DataFrame({'Subject': ['subject-1', 'subject-1', 'subject-2'],
@@ -382,6 +383,242 @@ class FilterSamplesTests(unittest.TestCase):
                          ['O1', 'O2'],
                          ['S2'])
         self.assertEqual(actual, expected)
+
+    def test_combine_exclude_ids_and_filters(self):
+        # exclude one, filter none - min_frequency
+        df = pd.DataFrame({'Subject': ['subject-1'],
+                           'SampleType': ['gut']},
+                          index=['S1'])
+        metadata = qiime2.Metadata(df)
+        table = Table(np.array([[0, 1, 3], [1, 1, 2]]),
+                      ['O1', 'O2'],
+                      ['S1', 'S2', 'S3'])
+        actual = filter_samples(table,
+                                metadata=metadata,
+                                exclude_ids=True,
+                                min_frequency=2)
+        expected = Table(np.array([[1, 3], [1, 2]]),
+                         ['O1', 'O2'],
+                         ['S2', 'S3'])
+        self.assertEqual(actual, expected)
+
+        # exclude one, filter one - min_frequency
+        df = pd.DataFrame({'Subject': ['subject-1'],
+                           'SampleType': ['gut']},
+                          index=['S1'])
+        metadata = qiime2.Metadata(df)
+        table = Table(np.array([[0, 1, 3], [1, 1, 2]]),
+                      ['O1', 'O2'],
+                      ['S1', 'S2', 'S3'])
+        actual = filter_samples(table,
+                                metadata=metadata,
+                                exclude_ids=True,
+                                min_frequency=3)
+        expected = Table(np.array([[3], [2]]),
+                         ['O1', 'O2'],
+                         ['S3'])
+        self.assertEqual(actual, expected)
+
+        # exclude one, no filtering - max_frequency
+        df = pd.DataFrame({'Subject': ['subject-1'],
+                           'SampleType': ['gut']},
+                          index=['S1'])
+        metadata = qiime2.Metadata(df)
+        table = Table(np.array([[0, 1, 3], [1, 1, 2]]),
+                      ['O1', 'O2'],
+                      ['S1', 'S2', 'S3'])
+        actual = filter_samples(table,
+                                metadata=metadata,
+                                exclude_ids=True,
+                                max_frequency=42)
+        expected = Table(np.array([[1, 3], [1, 2]]),
+                         ['O1', 'O2'],
+                         ['S2', 'S3'])
+        self.assertEqual(actual, expected)
+
+        # exclude one, filter one - max_frequency
+        df = pd.DataFrame({'Subject': ['subject-1'],
+                           'SampleType': ['gut']},
+                          index=['S1'])
+        metadata = qiime2.Metadata(df)
+        table = Table(np.array([[0, 1, 3], [1, 1, 2]]),
+                      ['O1', 'O2'],
+                      ['S1', 'S2', 'S3'])
+        actual = filter_samples(table,
+                                metadata=metadata,
+                                exclude_ids=True,
+                                max_frequency=4)
+        expected = Table(np.array([[1], [1]]),
+                         ['O1', 'O2'],
+                         ['S2'])
+        self.assertEqual(actual, expected)
+
+        # exclude one, no filtering - max&min_frequency
+        df = pd.DataFrame({'Subject': ['subject-1'],
+                           'SampleType': ['gut']},
+                          index=['S1'])
+        metadata = qiime2.Metadata(df)
+        table = Table(np.array([[0, 1, 3], [1, 1, 2]]),
+                      ['O1', 'O2'],
+                      ['S1', 'S2', 'S3'])
+        actual = filter_samples(table,
+                                metadata=metadata,
+                                exclude_ids=True,
+                                max_frequency=42,
+                                min_frequency=0)
+        expected = Table(np.array([[1, 3], [1, 2]]),
+                         ['O1', 'O2'],
+                         ['S2', 'S3'])
+        self.assertEqual(actual, expected)
+
+        # exclude one, filter one - max&min_frequency
+        df = pd.DataFrame({'Subject': ['subject-1'],
+                           'SampleType': ['gut']},
+                          index=['S1'])
+        metadata = qiime2.Metadata(df)
+        table = Table(np.array([[0, 1, 3], [1, 1, 2]]),
+                      ['O1', 'O2'],
+                      ['S1', 'S2', 'S3'])
+        actual = filter_samples(table,
+                                metadata=metadata,
+                                exclude_ids=True,
+                                max_frequency=4,
+                                min_frequency=3)
+        expected = Table(np.array([]), [], [])
+        self.assertEqual(actual, expected)
+
+        # exclude one, filter none - min_features
+        df = pd.DataFrame({'Subject': ['subject-1'],
+                           'SampleType': ['gut']},
+                          index=['S1'])
+        metadata = qiime2.Metadata(df)
+        table = Table(np.array([[0, 1, 3], [1, 1, 2]]),
+                      ['O1', 'O2'],
+                      ['S1', 'S2', 'S3'])
+        actual = filter_samples(table,
+                                metadata=metadata,
+                                exclude_ids=True,
+                                min_features=2)
+        expected = Table(np.array([[1, 3], [1, 2]]),
+                         ['O1', 'O2'],
+                         ['S2', 'S3'])
+        self.assertEqual(actual, expected)
+
+        # exclude one, filter two - min_features
+        df = pd.DataFrame({'Subject': ['subject-1'],
+                           'SampleType': ['gut']},
+                          index=['S2'])
+        metadata = qiime2.Metadata(df)
+        table = Table(np.array([[0, 1, 3], [1, 1, 2]]),
+                      ['O1', 'O2'],
+                      ['S1', 'S2', 'S3'])
+        actual = filter_samples(table,
+                                metadata=metadata,
+                                exclude_ids=True,
+                                min_features=2)
+        expected = Table(np.array([[3], [2]]),
+                         ['O1', 'O2'],
+                         ['S3'])
+        self.assertEqual(actual, expected)
+
+        # exclude one, filter none - max_features
+        df = pd.DataFrame({'Subject': ['subject-1'],
+                           'SampleType': ['gut']},
+                          index=['S1'])
+        metadata = qiime2.Metadata(df)
+        table = Table(np.array([[0, 1, 3], [1, 1, 2]]),
+                      ['O1', 'O2'],
+                      ['S1', 'S2', 'S3'])
+        actual = filter_samples(table,
+                                metadata=metadata,
+                                exclude_ids=True,
+                                max_features=3)
+        expected = Table(np.array([[1, 3], [1, 2]]),
+                         ['O1', 'O2'],
+                         ['S2', 'S3'])
+        self.assertEqual(actual, expected)
+
+        # exclude one, filter two - max_features
+        df = pd.DataFrame({'Subject': ['subject-1'],
+                           'SampleType': ['gut']},
+                          index=['S1'])
+        metadata = qiime2.Metadata(df)
+        table = Table(np.array([[0, 1, 3], [1, 1, 2]]),
+                      ['O1', 'O2'],
+                      ['S1', 'S2', 'S3'])
+        actual = filter_samples(table,
+                                metadata=metadata,
+                                exclude_ids=True,
+                                max_features=1)
+        expected = Table(np.array([]), [], [])
+        self.assertEqual(actual, expected)
+
+        # exclude one, filter none - min&max_features
+        df = pd.DataFrame({'Subject': ['subject-1'],
+                           'SampleType': ['gut']},
+                          index=['S1'])
+        metadata = qiime2.Metadata(df)
+        table = Table(np.array([[0, 1, 3], [1, 1, 2]]),
+                      ['O1', 'O2'],
+                      ['S1', 'S2', 'S3'])
+        actual = filter_samples(table,
+                                metadata=metadata,
+                                exclude_ids=True,
+                                min_features=1,
+                                max_features=3)
+        expected = Table(np.array([[1, 3], [1, 2]]),
+                         ['O1', 'O2'],
+                         ['S2', 'S3'])
+        self.assertEqual(actual, expected)
+
+        # exclude one, filter one - min&max_features
+        df = pd.DataFrame({'Subject': ['subject-1'],
+                           'SampleType': ['gut']},
+                          index=['S2'])
+        metadata = qiime2.Metadata(df)
+        table = Table(np.array([[0, 1, 3], [1, 1, 1]]),
+                      ['O1', 'O2'],
+                      ['S1', 'S2', 'S3'])
+        actual = filter_samples(table,
+                                metadata=metadata,
+                                exclude_ids=True,
+                                min_features=2,
+                                max_features=2)
+        expected = Table(np.array([[3], [1]]),
+                         ['O1', 'O2'],
+                         ['S3'])
+        self.assertEqual(actual, expected)
+
+        # exclude one, filter two - min&max_features
+        df = pd.DataFrame({'Subject': ['subject-1'],
+                           'SampleType': ['gut']},
+                          index=['S2'])
+        metadata = qiime2.Metadata(df)
+        table = Table(np.array([[0, 1, 3], [1, 1, 0]]),
+                      ['O1', 'O2'],
+                      ['S1', 'S2', 'S3'])
+        actual = filter_samples(table,
+                                metadata=metadata,
+                                exclude_ids=True,
+                                min_features=2,
+                                max_features=2)
+        expected = Table(np.array([]), [], [])
+        self.assertEqual(actual, expected)
+
+        # exclude one, filter two - where
+        df = pd.DataFrame({'Subject': ['subject-1', 'subject-1', 'subject-2'],
+                           'SampleType': ['gut', 'tongue', 'gut']},
+                          index=pd.Index(['S1', 'S2', 'S3'], name='#SampleID'))
+        metadata = qiime2.Metadata(df)
+        table = Table(np.array([[0, 1, 3], [1, 1, 2]]),
+                      ['O1', 'O2'],
+                      ['S1', 'S2', 'S3'])
+        where = "Subject='subject-1' AND SampleType='gut'"
+        with self.assertRaisesRegex(ValueError,
+                                    "'exclude_ids' must be false if "
+                                    "'where' is specified."):
+            filter_samples(table, metadata=metadata,
+                           where=where, exclude_ids=True)
 
 
 class FilterFeaturesTests(unittest.TestCase):
@@ -524,11 +761,6 @@ class FilterFeaturesTests(unittest.TestCase):
         actual = filter_features(table, metadata=metadata, where=where)
         expected = Table(np.array([]), [], [])
         self.assertEqual(actual, expected)
-
-        # exclude all and no metadata
-        with self.assertRaises(ValueError):
-            filter_features(table, metadata=None, where=where,
-                            exclude_ids=True)
 
 
 if __name__ == "__main__":

--- a/q2_feature_table/tests/test_filter.py
+++ b/q2_feature_table/tests/test_filter.py
@@ -203,6 +203,44 @@ class FilterSamplesTests(unittest.TestCase):
         expected = Table(np.array([]), [], [])
         self.assertEqual(actual, expected)
 
+        # exclude one
+        df = pd.DataFrame({'Subject': ['subject-1'],
+                           'SampleType': ['gut']},
+                          index=['S1'])
+        metadata = qiime2.Metadata(df)
+        table = Table(np.array([[0, 1, 3], [1, 1, 2]]),
+                      ['O1', 'O2'],
+                      ['S1', 'S2', 'S3'])
+        actual = filter_samples(table, metadata=metadata, exclude_ids=True)
+        expected = Table(np.array([[1, 3], [1, 2]]),
+                         ['O1', 'O2'],
+                         ['S2', 'S3'])
+        self.assertEqual(actual, expected)
+
+        # exclude two
+        df = pd.DataFrame({'Subject': ['subject-1', 'subject-1'],
+                           'SampleType': ['gut', 'tongue']},
+                          index=['S1', 'S2'])
+        metadata = qiime2.Metadata(df)
+        table = Table(np.array([[0, 1, 3], [1, 1, 2]]),
+                      ['O1', 'O2'],
+                      ['S1', 'S2', 'S3'])
+        actual = filter_samples(table, metadata=metadata, exclude_ids=True)
+        expected = Table(np.array([[3], [2]]),
+                         ['O1', 'O2'],
+                         ['S3'])
+        self.assertEqual(actual, expected)
+
+        # exclude all
+        df = pd.DataFrame({'Subject': ['subject-1', 'subject-1', 'subject-2'],
+                           'SampleType': ['gut', 'tongue', 'gut']},
+                          index=['S1', 'S2', 'S3'])
+        metadata = qiime2.Metadata(df)
+        actual = filter_samples(table, metadata=metadata,
+                                exclude_ids=True)
+        expected = Table(np.array([]), [], [])
+        self.assertEqual(actual, expected)
+
     def test_sample_metadata_extra_ids(self):
         df = pd.DataFrame({'Subject': ['subject-1', 'subject-1', 'subject-2'],
                            'SampleType': ['gut', 'tongue', 'gut']},
@@ -275,6 +313,11 @@ class FilterSamplesTests(unittest.TestCase):
         actual = filter_samples(table, metadata=metadata, where=where)
         expected = Table(np.array([]), [], [])
         self.assertEqual(actual, expected)
+
+        # exclude all and no metadata
+        with self.assertRaises(ValueError):
+            filter_samples(table, metadata=None, where=where,
+                           exclude_ids=True)
 
     def test_combine_id_and_frequency_filters(self):
         # no filtering
@@ -415,6 +458,32 @@ class FilterFeaturesTests(unittest.TestCase):
         expected = Table(np.array([]), [], [])
         self.assertEqual(actual, expected)
 
+        # exclude one
+        df = pd.DataFrame({'SequencedGenome': ['yes']},
+                          index=['O1'])
+        metadata = qiime2.Metadata(df)
+        table = Table(np.array([[0, 1, 3], [1, 1, 2]]),
+                      ['O1', 'O2'],
+                      ['S1', 'S2', 'S3'])
+        actual = filter_features(table, metadata=metadata,
+                                 exclude_ids=True)
+        expected = Table(np.array([[1, 1, 2]]),
+                         ['O2'],
+                         ['S1', 'S2', 'S3'])
+        self.assertEqual(actual, expected)
+
+        # exclude all
+        df = pd.DataFrame({'SequencedGenome': ['yes', 'yes']},
+                          index=['O1', 'O2'])
+        metadata = qiime2.Metadata(df)
+        table = Table(np.array([[0, 1, 3], [1, 1, 2]]),
+                      ['O1', 'O2'],
+                      ['S1', 'S2', 'S3'])
+        actual = filter_features(table, metadata=metadata,
+                                 exclude_ids=True)
+        expected = Table(np.array([]), [], [])
+        self.assertEqual(actual, expected)
+
     def test_where(self):
         # no filtering
         df = pd.DataFrame({'SequencedGenome': ['yes', 'no']},
@@ -455,6 +524,11 @@ class FilterFeaturesTests(unittest.TestCase):
         actual = filter_features(table, metadata=metadata, where=where)
         expected = Table(np.array([]), [], [])
         self.assertEqual(actual, expected)
+
+        # exclude all and no metadata
+        with self.assertRaises(ValueError):
+            filter_features(table, metadata=None, where=where,
+                            exclude_ids=True)
 
 
 if __name__ == "__main__":

--- a/q2_feature_table/tests/test_filter.py
+++ b/q2_feature_table/tests/test_filter.py
@@ -30,7 +30,7 @@ class FilterSamplesTests(unittest.TestCase):
             filter_samples(table, where="Subject='subject-1'")
 
         with self.assertRaisesRegex(ValueError,
-                                    "'exclude_ids' is true."):
+                                    "'exclude_ids' is True."):
             filter_samples(table, exclude_ids=True)
 
     def test_min_frequency(self):
@@ -207,6 +207,17 @@ class FilterSamplesTests(unittest.TestCase):
         actual = filter_samples(table, metadata=metadata)
         expected = Table(np.array([]), [], [])
         self.assertEqual(actual, expected)
+
+        # exclude none
+        df = pd.DataFrame({'Subject': ['subject-1'],
+                           'SampleType': ['gut']},
+                          index=['S90'])
+        metadata = qiime2.Metadata(df)
+        table = Table(np.array([[0, 1, 3], [1, 1, 2]]),
+                      ['O1', 'O2'],
+                      ['S1', 'S2', 'S3'])
+        actual = filter_samples(table, metadata=metadata, exclude_ids=True)
+        self.assertEqual(actual, table)
 
         # exclude one
         df = pd.DataFrame({'Subject': ['subject-1'],


### PR DESCRIPTION
This PR addresses Issue #101 .

I've added an optional `exclude_ids` flag to `filter_features` and `filter_samples`.  I declared the new flag in the plugin setup and added unit tests.

This flag is set to `False` by default.  If it is specified as true, then the filter function in question returns the inverse of what it would otherwise return.  For example:

````PYTHON
df = pd.DataFrame({'SequencedGenome': ['yes']},
                          index=['O1'])
metadata = qiime2.Metadata(df)
table = Table(np.array([[0, 1, 3], [1, 1, 2]]),
                      ['O1', 'O2'],
                      ['S1', 'S2', 'S3'])
filter_features(table, metadata=metadata)
````

... returns:

````BASH
#OTU ID	S2	S3
O1	1.0	3.0
````
This makes sense: we asked for the stuff in `index=['01']`, and we got it.

In comparison, if we set `exclude_ids=True`, we get:

````PYTHON
filter_features(table, metadata=metadata, exclude_ids=True)
````

````BASH
#OTU ID	S1	S2	S3
O2	1.0	1.0	2.0
````

And this also makes sense: we asked for the stuff *not* in `index=['01']`, and, indeed, we got everything not in that index (in this case the only other index being `02`).