### PR TITLE
ENH: add `core-features` visualizer

### DIFF
--- a/q2_feature_table/__init__.py
+++ b/q2_feature_table/__init__.py
@@ -11,6 +11,7 @@ from ._transform import (presence_absence, relative_frequency)
 from ._summarize import (summarize, tabulate_seqs)
 from ._merge import (merge, merge_seq_data, merge_taxa_data, overlap_methods)
 from ._filter import (filter_samples, filter_features)
+from ._core_features import core_features
 from ._version import get_versions
 
 __version__ = get_versions()['version']
@@ -18,4 +19,5 @@ del get_versions
 
 __all__ = ['rarefy', 'presence_absence', 'relative_frequency', 'summarize',
            'merge', 'merge_seq_data', 'filter_samples', 'filter_features',
-           'merge_taxa_data', 'tabulate_seqs', 'overlap_methods']
+           'merge_taxa_data', 'tabulate_seqs', 'overlap_methods',
+           'core_features']

--- a/q2_feature_table/_core_features/__init__.py
+++ b/q2_feature_table/_core_features/__init__.py
@@ -1,0 +1,11 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016-2017, QIIME 2 development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+
+from ._visualizer import core_features
+
+__all__ = ['core_features']

--- a/q2_feature_table/_core_features/_visualizer.py
+++ b/q2_feature_table/_core_features/_visualizer.py
@@ -98,10 +98,6 @@ def _get_core_features(table, fraction):
 
 
 def _get_filter_to_core_f(table, fraction):
-    if not (0.0 <= fraction <= 1.0):
-        raise ValueError("Invalid fraction passed to core filter: %r is "
-                         "outside of range [0,1]." % fraction)
-
     # determine the number of samples that must have a non-zero value for a
     # feature to be considered part of the core
     min_count = fraction * table.shape[1]

--- a/q2_feature_table/_core_features/_visualizer.py
+++ b/q2_feature_table/_core_features/_visualizer.py
@@ -1,0 +1,171 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016-2017, QIIME 2 development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+
+import os.path
+import pkg_resources
+
+import biom
+import q2templates
+import numpy as np
+import pandas as pd
+import seaborn as sns
+
+
+TEMPLATES = pkg_resources.resource_filename(
+    'q2_feature_table._core_features', 'core_features_assets')
+
+
+def core_features(output_dir, table: biom.Table, min_fraction: float=0.5,
+                  max_fraction: float=1.0, steps: int=11) -> None:
+    if max_fraction < min_fraction:
+        raise ValueError('min_fraction (%r) parameter must be less than '
+                         'max_fraction (%r) parameter.' %
+                         (min_fraction, max_fraction))
+
+    index_fp = os.path.join(TEMPLATES, 'index.html')
+    context = {
+        'num_samples': table.shape[1],
+        'num_features': table.shape[0]
+    }
+
+    if min_fraction == max_fraction:
+        fractions = [min_fraction]
+    else:
+        fractions = np.linspace(min_fraction, max_fraction, steps)
+
+    rounded_fractions = _round_fractions(fractions)
+
+    data = []
+    file_links = []
+    for fraction, rounded_fraction in zip(fractions, rounded_fractions):
+        core_features = _get_core_features(table, fraction)
+        core_feature_count = len(core_features)
+        data.append([fraction, core_feature_count])
+
+        if core_feature_count > 0:
+            core_feature_fn = 'core-features-%s.tsv' % rounded_fraction
+            core_feature_fp = os.path.join(output_dir, core_feature_fn)
+
+            file_links.append("<a href='./%s'>TSV</a>" % core_feature_fn)
+
+            core_features.to_csv(core_feature_fp, sep='\t',
+                                 index_label='Feature ID')
+        else:
+            file_links.append('No core features')
+
+    df = pd.DataFrame(data, columns=['Fraction of samples', 'Feature count'])
+    df['Fraction of features'] = df['Feature count'] / table.shape[0]
+    df['Feature list'] = file_links
+
+    ax = sns.regplot(data=df, x='Fraction of samples', y='Feature count',
+                     fit_reg=False)
+
+    # matplotlib will issue a UserWarning if attempting to set left and right
+    # bounds to the same value.
+    if min_fraction != max_fraction:
+        ax.set_xbound(min(fractions), max(fractions))
+    ax.set_ybound(0, max(df['Feature count']) + 1)
+
+    ax.get_figure().savefig(
+        os.path.join(output_dir, 'core-feature-counts.svg'))
+
+    table_html = _df_to_html(df, index=False, escape=False, border=0,
+                             classes=("table table-striped table-hover"))
+    context['table_html'] = table_html
+
+    q2templates.render(index_fp, output_dir, context=context)
+
+
+def _get_core_features(table, fraction):
+    filter_f = _get_filter_to_core_f(table, fraction)
+    feature_filtered_table = table.filter(
+        filter_f, axis='observation', inplace=False)
+    index = []
+    data = []
+    for values, id_, _ in feature_filtered_table.iter(axis='observation'):
+        index.append(id_)
+        data.append(_seven_number_summary(values))
+    if len(data) > 0:
+        return pd.DataFrame(data, index=index).sort_values(
+            by='50%', ascending=False)
+    else:
+        return pd.DataFrame()
+
+
+def _get_filter_to_core_f(table, fraction):
+    if not (0.0 <= fraction <= 1.0):
+        raise ValueError("Invalid fraction passed to core filter: %r is "
+                         "outside of range [0,1]." % fraction)
+
+    # determine the number of samples that must have a non-zero value for a
+    # feature to be considered part of the core
+    min_count = fraction * table.shape[1]
+
+    def f(values, *_):
+        return np.count_nonzero(values) >= min_count
+    return f
+
+
+def _seven_number_summary(a):
+    # TODO this should probably be publicly accessible throughout QIIME 2. it's
+    # also currently implemented in q2-demux `summarize` and q2-diversity
+    # `alpha-rarefaction`
+    stats = pd.Series(a).describe(
+        percentiles=[0.02, 0.09, 0.25, 0.5, 0.75, 0.91, 0.98])
+    drop_cols = stats.index.isin(['std', 'mean', 'min', 'max', 'count'])
+    stats = stats[~drop_cols]
+    return stats
+
+
+# TODO move this function into a util package somewhere that's accessible to
+# QIIME 2 packages.
+def _df_to_html(df, **kwargs):
+    """Convert a dataframe to HTML without truncating contents.
+
+    pandas will truncate cell contents that exceed 50 characters by default.
+    Use this function to avoid this truncation behavior.
+
+    Details:
+
+    https://stackoverflow.com/q/26277757/3776794
+    https://github.com/pandas-dev/pandas/issues/1852
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        DataFrame to convert to HTML.
+    kwargs : dict
+        Parameters passed through to `pd.DataFrame.to_html`.
+
+    """
+    with pd.option_context('display.max_colwidth', -1):
+        return df.to_html(**kwargs)
+
+
+def _round_fractions(fractions):
+    """Format float fractions as rounded fraction strings.
+
+    Fractions are rounded as short as possible without losing the precision
+    necessary to distinguish one fraction from another. The rounding starts at
+    3 decimal places and continues up to 10 decimal places, if a shorter
+    rounded representation isn't converged upon earlier. If rounding at 10
+    decimal places doesn't provide enough precision, each fraction's full
+    float precision will be used (i.e. as returned by `repr(float)`).
+
+    For example, [0.12345, 0.12351] would be rounded to four decimal places:
+    ['0.1234', '0.1235']. 3 decimal places would be tried first but there isn't
+    enough precision to keep both fractions distinguishable.
+
+    """
+    for decimals in range(3, 11):
+        rounded = ['{fraction:1.{decimals}f}'.format(fraction=fraction,
+                                                     decimals=decimals)
+                   for fraction in fractions]
+        if len(rounded) == len(set(rounded)):
+            return rounded
+    return [repr(fraction) for fraction in fractions]

--- a/q2_feature_table/_core_features/core_features_assets/index.html
+++ b/q2_feature_table/_core_features/core_features_assets/index.html
@@ -23,10 +23,10 @@
     <div class='row'>
       <div class='col-md-12'>
         <h3>Terminology key</h3>
-        <i>Fraction of samples</i>: The fraction of the total number of samples that a feature must be observed more than zero times in for that feature to be considered "core".<br>
-        <i>Feature count</i>: The number of "core" features at a given fraction of samples.<br>
-        <i>Fraction of features</i>: The fraction of the total number of features that are "core" features at a given fraction of samples.<br>
-        <i>Feature list</i>: The list of "core" feature ids and their percentile frequencies at a given fraction of samples.
+        <i>Fraction of samples</i>: The fraction of the total number of samples that a feature must be observed in for that feature to be considered "core".<br>
+        <i>Feature count</i>: The number of "core" features.<br>
+        <i>Fraction of features</i>: The fraction of the total number of features that are "core" features.<br>
+        <i>Feature list</i>: The list of "core" feature IDs and their total percentile frequencies.
       </div>
     </div>
     <div class='row'>

--- a/q2_feature_table/_core_features/core_features_assets/index.html
+++ b/q2_feature_table/_core_features/core_features_assets/index.html
@@ -1,0 +1,40 @@
+{% extends 'base.html' %}
+
+{% block content %}
+
+<h1>Core features</h1>
+
+<div class='row'>
+  <div class='col-md-6'>
+    <div class='row'>
+      <div class='col-md-12'>
+        <h3>Feature table summary</h3>
+        Sample count: {{num_samples}}<br>
+        Feature count: {{num_features}}
+      </div>
+    </div>
+    <div class='row'>
+      <div class='col-md-12'>
+        <img src='core-feature-counts.svg'>
+      </div>
+    </div>
+  </div>
+  <div class='col-md-6'>
+    <div class='row'>
+      <div class='col-md-12'>
+        <h3>Terminology key</h3>
+        <i>Fraction of samples</i>: The fraction of the total number of samples that a feature must be observed more than zero times in for that feature to be considered "core".<br>
+        <i>Feature count</i>: The number of "core" features at a given fraction of samples.<br>
+        <i>Fraction of features</i>: The fraction of the total number of features that are "core" features at a given fraction of samples.<br>
+        <i>Feature list</i>: The list of "core" feature ids and their percentile frequencies at a given fraction of samples.
+      </div>
+    </div>
+    <div class='row'>
+      <div class='col-md-12'>
+        {{table_html}}
+      </div>
+    </div>
+  </div>
+</div>
+
+{% endblock %}

--- a/q2_feature_table/plugin_setup.py
+++ b/q2_feature_table/plugin_setup.py
@@ -299,13 +299,12 @@ plugin.visualizers.register_function(
         'steps': Int % Range(2, None)
     },
     name='Identify core features in table',
-    description=('Identify "core" features, which are features observed more '
-                 'than zero times in a user-defined fraction of the samples. '
-                 'Since the core features are a function of the fraction of '
-                 'samples that the feature must be observed in to be '
-                 'considered core, this is computed over a range of fractions '
-                 'defined by the `min_fraction`, `max_fraction`, and `steps` '
-                 'parameters.'),
+    description=('Identify "core" features, which are features observed in a '
+                 'user-defined fraction of the samples. Since the core '
+                 'features are a function of the fraction of samples that the '
+                 'feature must be observed in to be considered core, this is '
+                 'computed over a range of fractions defined by the '
+                 '`min_fraction`, `max_fraction`, and `steps` parameters.'),
     input_descriptions={
         'table': 'The feature table to use in core features calculations.'
     },

--- a/q2_feature_table/plugin_setup.py
+++ b/q2_feature_table/plugin_setup.py
@@ -6,7 +6,8 @@
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
-from qiime2.plugin import Plugin, Int, Metadata, Str, Bool, Choices
+from qiime2.plugin import (Plugin, Int, Float, Range, Metadata, Str, Bool,
+                           Choices)
 
 import q2_feature_table
 from q2_types.feature_table import (
@@ -209,7 +210,7 @@ plugin.methods.register_function(
     output_descriptions={
         'filtered_table': 'The resulting feature table filtered by sample.'
     },
-    name="Filter samples from table.",
+    name="Filter samples from table",
     description="Filter samples from table based on frequency and/or "
                 "metadata. Any features with a frequency of zero after sample "
                 "filtering will also be removed. See the filtering tutorial "
@@ -257,7 +258,7 @@ plugin.methods.register_function(
     output_descriptions={
         'filtered_table': 'The resulting feature table filtered by feature.'
     },
-    name="Filter features from table.",
+    name="Filter features from table",
     description="Filter features from table based on frequency and/or "
                 "metadata. Any samples with a frequency of zero after feature "
                 "filtering will also be removed. See the filtering tutorial "
@@ -285,4 +286,39 @@ plugin.visualizers.register_function(
     description="Generate tabular view of feature identifier to sequence "
                 "mapping, including links to BLAST each sequence against "
                 "the NCBI nt database."
+)
+
+plugin.visualizers.register_function(
+    function=q2_feature_table.core_features,
+    inputs={
+        'table': FeatureTable[Frequency]
+    },
+    parameters={
+        'min_fraction': Float % Range(0.0, 1.0, inclusive_start=False),
+        'max_fraction': Float % Range(0.0, 1.0, inclusive_end=True),
+        'steps': Int % Range(2, None)
+    },
+    name='Identify core features in table',
+    description=('Identify "core" features, which are features observed more '
+                 'than zero times in a user-defined fraction of the samples. '
+                 'Since the core features are a function of the fraction of '
+                 'samples that the feature must be observed in to be '
+                 'considered core, this is computed over a range of fractions '
+                 'defined by the `min_fraction`, `max_fraction`, and `steps` '
+                 'parameters.'),
+    input_descriptions={
+        'table': 'The feature table to use in core features calculations.'
+    },
+    parameter_descriptions={
+        'min_fraction': 'The minimum fraction of samples that a feature must '
+                        'be observed in for that feature to be considered a '
+                        'core feature.',
+        'max_fraction': 'The maximum fraction of samples that a feature must '
+                        'be observed in for that feature to be considered a '
+                        'core feature.',
+        'steps': 'The number of steps to take between `min_fraction` and '
+                 '`max_fraction` for core features calculations. This '
+                 'parameter has no effect if `min_fraction` and '
+                 '`max_fraction` are the same value.'
+    }
 )

--- a/q2_feature_table/tests/test_core_features.py
+++ b/q2_feature_table/tests/test_core_features.py
@@ -1,0 +1,249 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016-2017, QIIME 2 development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+
+import glob
+import unittest
+import tempfile
+import os.path
+
+import biom
+import numpy as np
+import pandas as pd
+import pandas.testing as pdt
+
+from q2_feature_table import core_features
+from q2_feature_table._core_features._visualizer import (
+    _get_core_features, _seven_number_summary, _round_fractions)
+
+
+class TestCoreFeatures(unittest.TestCase):
+    def setUp(self):
+        self.table = biom.Table(np.array([[0, 11, 11], [13, 11, 11]]),
+                                ['O1', 'O2'], ['S1', 'S2', 'S3'])
+        self.output_dir_obj = tempfile.TemporaryDirectory(
+                prefix='q2-feature-table-test-temp-')
+        self.output_dir = self.output_dir_obj.name
+
+    def tearDown(self):
+        self.output_dir_obj.cleanup()
+
+    def assertBasicVizValidity(self, viz_dir, exp_sample_count=3,
+                               exp_feature_count=2, exp_no_core=False):
+        index_fp = os.path.join(viz_dir, 'index.html')
+        self.assertTrue(os.path.exists(index_fp))
+        with open(index_fp, 'r') as fh:
+            index_contents = fh.read()
+
+        self.assertIn('Sample count: %d' % exp_sample_count, index_contents)
+        self.assertIn('Feature count: %d' % exp_feature_count, index_contents)
+        if exp_no_core:
+            self.assertIn('No core features', index_contents)
+
+        svg_fp = os.path.join(viz_dir, 'core-feature-counts.svg')
+        self.assertTrue(os.path.exists(svg_fp))
+
+    def assertCoreFeaturesPresent(self, filepath, positive_ids, negative_ids):
+        self.assertTrue(os.path.exists(filepath))
+
+        with open(filepath, 'r') as fh:
+            contents = fh.read()
+
+        for positive_id in positive_ids:
+            self.assertIn(positive_id, contents)
+
+        for negative_id in negative_ids:
+            self.assertNotIn(negative_id, contents)
+
+    def test_defaults(self):
+        core_features(self.output_dir, self.table)
+
+        self.assertBasicVizValidity(self.output_dir)
+
+        core_50_fp = os.path.join(self.output_dir, 'core-features-0.500.tsv')
+        self.assertCoreFeaturesPresent(core_50_fp, ['O1', 'O2'], [])
+
+        core_100_fp = os.path.join(self.output_dir, 'core-features-1.000.tsv')
+        self.assertCoreFeaturesPresent(core_100_fp, ['O2'], ['O1'])
+
+    def test_fraction_range(self):
+        core_features(self.output_dir, self.table, min_fraction=0.55,
+                      max_fraction=0.95, steps=9)
+
+        self.assertBasicVizValidity(self.output_dir)
+
+        core_50_fp = os.path.join(self.output_dir, 'core-features-0.500.tsv')
+        self.assertFalse(os.path.exists(core_50_fp))
+
+        core_55_fp = os.path.join(self.output_dir, 'core-features-0.550.tsv')
+        self.assertCoreFeaturesPresent(core_55_fp, ['O1', 'O2'], [])
+
+        core_95_fp = os.path.join(self.output_dir, 'core-features-0.950.tsv')
+        self.assertCoreFeaturesPresent(core_95_fp, ['O2'], ['O1'])
+
+        core_100_fp = os.path.join(self.output_dir, 'core-features-1.000.tsv')
+        self.assertFalse(os.path.exists(core_100_fp))
+
+    def test_minimum_number_of_steps(self):
+        core_features(self.output_dir, self.table, min_fraction=0.55,
+                      max_fraction=0.95, steps=2)
+
+        self.assertBasicVizValidity(self.output_dir)
+
+        core_55_fp = os.path.join(self.output_dir, 'core-features-0.550.tsv')
+        core_95_fp = os.path.join(self.output_dir, 'core-features-0.950.tsv')
+        tsv_files = sorted(glob.glob(os.path.join(self.output_dir, '*.tsv')))
+        self.assertEqual(tsv_files, [core_55_fp, core_95_fp])
+
+        self.assertCoreFeaturesPresent(core_55_fp, ['O1', 'O2'], [])
+        self.assertCoreFeaturesPresent(core_95_fp, ['O2'], ['O1'])
+
+    def test_equal_min_max_fractions(self):
+        core_features(self.output_dir, self.table, min_fraction=0.55,
+                      max_fraction=0.55)
+
+        self.assertBasicVizValidity(self.output_dir)
+
+        core_55_fp = os.path.join(self.output_dir, 'core-features-0.550.tsv')
+        tsv_files = glob.glob(os.path.join(self.output_dir, '*.tsv'))
+        self.assertEqual(tsv_files, [core_55_fp])
+
+        self.assertCoreFeaturesPresent(core_55_fp, ['O1', 'O2'], [])
+
+    def test_tiny_steps_precision(self):
+        # Bug in a previous iteration of the code used a fixed number of digits
+        # in the "feature list" TSV filenames, causing files to be overwritten
+        # with the wrong data if a small enough step size was used.
+        core_features(self.output_dir, self.table, min_fraction=0.1,
+                      max_fraction=0.11, steps=101)
+
+        self.assertBasicVizValidity(self.output_dir)
+
+        fp = os.path.join(self.output_dir, 'core-features-0.1000.tsv')
+        self.assertTrue(os.path.exists(fp))
+
+        fp = os.path.join(self.output_dir, 'core-features-0.1001.tsv')
+        self.assertTrue(os.path.exists(fp))
+
+        fp = os.path.join(self.output_dir, 'core-features-0.1099.tsv')
+        self.assertTrue(os.path.exists(fp))
+
+        fp = os.path.join(self.output_dir, 'core-features-0.1100.tsv')
+        self.assertTrue(os.path.exists(fp))
+
+    def test_no_core_features(self):
+        table = biom.Table(np.array([[0, 11, 11], [11, 11, 0]]), ['O1', 'O2'],
+                           ['S1', 'S2', 'S3'])
+
+        core_features(self.output_dir, table)
+
+        self.assertBasicVizValidity(self.output_dir, exp_no_core=True)
+
+        core_50_fp = os.path.join(self.output_dir, 'core-features-0.500.tsv')
+        self.assertCoreFeaturesPresent(core_50_fp, ['O1', 'O2'], [])
+
+        # No core features exist at fraction=1.0
+        core_100_fp = os.path.join(self.output_dir, 'core-features-1.000.tsv')
+        self.assertFalse(os.path.exists(core_100_fp))
+
+    def test_empty_table(self):
+        table = biom.Table(np.array([[]]), [], [])
+
+        core_features(self.output_dir, table)
+
+        self.assertBasicVizValidity(self.output_dir, exp_sample_count=0,
+                                    exp_feature_count=0, exp_no_core=True)
+
+        self.assertFalse(glob.glob(os.path.join(self.output_dir, '*.tsv')))
+
+    def test_invalid_parameters(self):
+        with self.assertRaisesRegex(ValueError, 'fraction'):
+            core_features(self.output_dir, self.table, min_fraction=0.75,
+                          max_fraction=0.5)
+
+        with self.assertRaisesRegex(ValueError, 'Invalid fraction'):
+            core_features(self.output_dir, self.table, min_fraction=-0.01)
+
+        with self.assertRaisesRegex(ValueError, 'Invalid fraction'):
+            core_features(self.output_dir, self.table, max_fraction=1.01)
+
+
+class TestCoreFeaturesPrivateFunctions(unittest.TestCase):
+    # Most of the work happens in private functions for this visualizer,
+    # so it's important to have some tests of the private functionality
+
+    def test_seven_number_summary(self):
+        # validated against calling pd.Series.describe directly
+        exp = pd.Series([11., 11., 11., 11., 12., 12.64, 12.92],
+                        index=['2%', '9%', '25%', '50%', '75%', '91%', '98%'])
+        pdt.assert_series_equal(_seven_number_summary([13, 11, 11]), exp)
+
+        exp = pd.Series([1., 1., 1., 1., 1., 1., 1.],
+                        index=['2%', '9%', '25%', '50%', '75%', '91%', '98%'])
+        pdt.assert_series_equal(_seven_number_summary([1]), exp)
+
+        exp = pd.Series([np.nan, np.nan, np.nan, np.nan, np.nan,
+                         np.nan, np.nan],
+                        index=['2%', '9%', '25%', '50%', '75%', '91%', '98%'])
+        pdt.assert_series_equal(_seven_number_summary([]), exp)
+
+    def test_get_core_features(self):
+        table = biom.Table(np.array([[0, 11, 11], [13, 11, 11]]),
+                           ['O1', 'O2'],
+                           ['S1', 'S2', 'S3'])
+        o2_seven_num = pd.Series(
+            [11., 11., 11., 11., 12., 12.64, 12.92],
+            index=['2%', '9%', '25%', '50%', '75%', '91%', '98%'])
+        exp = pd.DataFrame([o2_seven_num], index=['O2'])
+
+        obs = _get_core_features(table, fraction=0.67)
+        pdt.assert_frame_equal(obs, exp)
+
+        obs = _get_core_features(table, fraction=1.0)
+        pdt.assert_frame_equal(obs, exp)
+
+    def test_get_core_features_all(self):
+        table = biom.Table(np.array([[0, 11, 11], [13, 11, 11]]),
+                           ['O1', 'O2'],
+                           ['S1', 'S2', 'S3'])
+        o1_seven_num = pd.Series(
+            [0.44, 1.98, 5.5, 11., 11., 11., 11.],
+            index=['2%', '9%', '25%', '50%', '75%', '91%', '98%'])
+        o2_seven_num = pd.Series(
+            [11., 11., 11., 11., 12., 12.64, 12.92],
+            index=['2%', '9%', '25%', '50%', '75%', '91%', '98%'])
+        exp = pd.DataFrame([o1_seven_num, o2_seven_num], index=['O1', 'O2'])
+
+        # fraction = 2/3 - 0.006
+        obs = _get_core_features(table, fraction=0.660)
+        pdt.assert_frame_equal(obs, exp)
+
+        obs = _get_core_features(table, fraction=0.0)
+        pdt.assert_frame_equal(obs, exp)
+
+    def test_round_fractions_single(self):
+        obs = _round_fractions([0.0])
+        self.assertEqual(obs, ['0.000'])
+
+        obs = _round_fractions([0.1236])
+        self.assertEqual(obs, ['0.124'])
+
+    def test_round_fractions_3_decimals(self):
+        obs = _round_fractions([0.1236, 0.45, 0.123])
+        self.assertEqual(obs, ['0.124', '0.450', '0.123'])
+
+    def test_round_fractions_4_decimals(self):
+        obs = _round_fractions([0.1234, 0.45, 0.0, 0.12346])
+        self.assertEqual(obs, ['0.1234', '0.4500', '0.0000', '0.1235'])
+
+    def test_round_fractions_full_precision(self):
+        obs = _round_fractions([0.01234567890, 0.01234567891])
+        self.assertEqual(obs, ['0.0123456789', '0.01234567891'])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/q2_feature_table/tests/test_core_features.py
+++ b/q2_feature_table/tests/test_core_features.py
@@ -165,12 +165,6 @@ class TestCoreFeatures(unittest.TestCase):
             core_features(self.output_dir, self.table, min_fraction=0.75,
                           max_fraction=0.5)
 
-        with self.assertRaisesRegex(ValueError, 'Invalid fraction'):
-            core_features(self.output_dir, self.table, min_fraction=-0.01)
-
-        with self.assertRaisesRegex(ValueError, 'Invalid fraction'):
-            core_features(self.output_dir, self.table, max_fraction=1.01)
-
 
 class TestCoreFeaturesPrivateFunctions(unittest.TestCase):
     # Most of the work happens in private functions for this visualizer,

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,9 @@ setup(
                         'summarize_assets/*.html',
                         'summarize_assets/dist/*',
                         'tabulate_seqs_assets/js/*',
-                        'tabulate_seqs_assets/index.html'
+                        'tabulate_seqs_assets/index.html'],
+                  'q2_feature_table._core_features': [
+                        'core_features_assets/index.html'
                   ]},
     author="Greg Caporaso",
     author_email="gregcaporaso@gmail.com",


### PR DESCRIPTION
Example .qzv: [core-features.qzv](https://view.qiime2.org/visualization/?type=html&src=https%3A%2F%2Fforum-qiime2-org.s3-us-west-2.amazonaws.com%2Foriginal%2F1X%2F89efca24e973aa4b164cddc9ce31360ddea942de.qzv)

Ported @gregcaporaso's code from https://github.com/qiime2/q2-diversity/pull/127 and made the following changes:

- All references to "core microbiome" are now "core features".

- Removed metadata-based filtering support from the viz in favor of using `filter-samples` or `filter-features`.

- Refactored unit tests to reduce code duplication, and added several new tests.

- Fixed a precision bug where small enough step sizes could cause "feature list" .tsv output files to be overwritten.

- Fixed a bug where HTML table contents could have been truncated.

- Better handling of the case where `min_fraction` and `max_fraction` are the same value (silenced a matplotlib warning, and ignores `steps` for efficiency and easier to interpret output).

- Updated code to use biom API more efficiently.

Fixes https://github.com/qiime2/q2-diversity/issues/122.