### PR TITLE
ENH: adds group method

### DIFF
--- a/q2_feature_table/__init__.py
+++ b/q2_feature_table/__init__.py
@@ -12,6 +12,7 @@ from ._summarize import (summarize, tabulate_seqs)
 from ._merge import (merge, merge_seq_data, merge_taxa_data, overlap_methods)
 from ._filter import (filter_samples, filter_features)
 from ._core_features import core_features
+from ._group import group
 from ._version import get_versions
 
 __version__ = get_versions()['version']
@@ -20,4 +21,4 @@ del get_versions
 __all__ = ['rarefy', 'presence_absence', 'relative_frequency', 'summarize',
            'merge', 'merge_seq_data', 'filter_samples', 'filter_features',
            'merge_taxa_data', 'tabulate_seqs', 'overlap_methods',
-           'core_features']
+           'core_features', 'group']

--- a/q2_feature_table/_group.py
+++ b/q2_feature_table/_group.py
@@ -56,6 +56,9 @@ def _munge_metadata_category(mc, ids):
 
 def group(table: biom.Table, axis: str, metadata: qiime2.MetadataCategory,
           mode: str) -> biom.Table:
+    if table.is_empty():
+        raise ValueError("Cannot group an empty table.")
+
     if axis == 'feature':
         axis = 'observation'
 

--- a/q2_feature_table/_group.py
+++ b/q2_feature_table/_group.py
@@ -1,0 +1,71 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016-2017, QIIME 2 development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+
+import biom
+import qiime2
+import numpy as np
+import pandas as pd
+
+
+def _collapse_factory(function):
+    def collapse_f(table, axis):
+        # axis is always the transpose of the original collapse axis
+        return np.array([function(x) for x in table.iter_data(axis=axis)])
+    return collapse_f
+
+
+_mode_lookup = {
+    'sum': _collapse_factory(np.sum),
+    'median-ceiling': _collapse_factory(lambda x: np.ceil(np.median(x))),
+    'mean-ceiling': _collapse_factory(lambda x: np.ceil(np.mean(x)))
+}
+
+
+def _munge_metadata_category(mc, ids):
+    # TODO: centralize these ideas in MetadataCategory somehow
+    series = mc.to_series()
+    table_ids = set(ids)
+    series_ids = set(series.index)
+
+    # Check numeric
+    if pd.api.types.is_numeric_dtype(pd.to_numeric(series, errors='ignore')):
+        raise ValueError("Cannot group by a numeric metadata category.")
+
+    # Check missing
+    missing_ids = table_ids - series_ids
+    if missing_ids:
+        raise ValueError("All IDs must be present in metadata category, but "
+                         " the following are missing: %r" % missing_ids)
+
+    # While preserving order, get rid of any IDs found only in the metadata
+    series = series.drop(series_ids - table_ids)
+
+    # Check for empty values only after filtering down to relevant IDs
+    missing_values = series.isnull() | (series == '')
+    if missing_values.any():
+        missing = set(series[missing_values].index)
+        raise ValueError("There are missing value(s) for ID(s): %r" % missing)
+
+    return series
+
+
+def group(table: biom.Table, axis: str, metadata: qiime2.MetadataCategory,
+          mode: str) -> biom.Table:
+    if axis == 'feature':
+        axis = 'observation'
+
+    series = _munge_metadata_category(metadata, ids=table.ids(axis=axis))
+
+    grouped_table = table.collapse(lambda axis_id, _: series.loc[axis_id],
+                                   collapse_f=_mode_lookup[mode],
+                                   axis=axis,
+                                   norm=False,
+                                   include_collapsed_metadata=False)
+    # Reorder axis by first unique appearance of each group value in metadata
+    # (makes it stable for identity mappings and easier to test)
+    return grouped_table.sort_order(series.unique(), axis=axis)

--- a/q2_feature_table/plugin_setup.py
+++ b/q2_feature_table/plugin_setup.py
@@ -108,20 +108,24 @@ plugin.methods.register_function(
         'table': 'The table to group samples or features on.'
     },
     parameter_descriptions={
-        'mode': 'How to combine observation frequencies within group.',
-        'metadata': ('A category defining the groups. Each unique value will '
-                     'become a new ID for the table on the given `axis`.'),
-        'axis': ('Along which axis to group. Each ID in the given axis must '
-                 'exist in `metadata`.')
+        'mode': 'How to combine samples or features within a group. `sum` '
+                'will sum the frequencies across all samples or features '
+                'within a group; `mean-ceiling` will take the ceiling of the '
+                'mean of these frequencies; `median-ceiling` will take the '
+                'ceiling of the median of these frequencies.',
+        'metadata': 'A category defining the groups. Each unique value will '
+                    'become a new ID for the table on the given `axis`.',
+        'axis': 'Along which axis to group. Each ID in the given axis must '
+                'exist in `metadata`.'
     },
     output_descriptions={
-        'grouped_table': ('A table that has been grouped along the given '
-                          '`axis`. IDs on that axis are replaced by values in '
-                          'the `metadata` category.')
+        'grouped_table': 'A table that has been grouped along the given '
+                         '`axis`. IDs on that axis are replaced by values in '
+                         'the `metadata` category.'
     },
-    name="Group a feature table by a metadata category",
-    description="Group a feature table along a given axis using metadata to "
-                "define the mapping of IDs to a group."
+    name="Group samples or features by a metadata category",
+    description="Group samples or features in a feature table using metadata "
+                "to define the mapping of IDs to a group."
 )
 
 plugin.methods.register_function(

--- a/q2_feature_table/plugin_setup.py
+++ b/q2_feature_table/plugin_setup.py
@@ -7,7 +7,7 @@
 # ----------------------------------------------------------------------------
 
 from qiime2.plugin import (Plugin, Int, Float, Range, Metadata, Str, Bool,
-                           Choices)
+                           Choices, MetadataCategory)
 
 import q2_feature_table
 from q2_types.feature_table import (
@@ -91,6 +91,37 @@ plugin.methods.register_function(
     description="Convert frequencies to relative frequencies by dividing each "
                 "frequency in a sample by the sum of frequencies in that "
                 "sample."
+)
+
+plugin.methods.register_function(
+    function=q2_feature_table.group,
+    inputs={'table': FeatureTable[Frequency]},
+    parameters={
+        'mode': Str % Choices({'sum', 'median-ceiling', 'mean-ceiling'}),
+        'metadata': MetadataCategory,
+        'axis': Str % Choices({'sample', 'feature'})
+    },
+    outputs=[
+        ('grouped_table', FeatureTable[Frequency])
+    ],
+    input_descriptions={
+        'table': 'The table to group samples or features on.'
+    },
+    parameter_descriptions={
+        'mode': 'How to combine observation frequencies within group.',
+        'metadata': ('A category defining the groups. Each unique value will '
+                     'become a new ID for the table on the given `axis`.'),
+        'axis': ('Along which axis to group. Each ID in the given axis must '
+                 'exist in `metadata`.')
+    },
+    output_descriptions={
+        'grouped_table': ('A table that has been grouped along the given '
+                          '`axis`. IDs on that axis are replaced by values in '
+                          'the `metadata` category.')
+    },
+    name="Group a feature table by a metadata category",
+    description="Group a feature table along a given axis using metadata to "
+                "define the mapping of IDs to a group."
 )
 
 plugin.methods.register_function(

--- a/q2_feature_table/tests/test_group.py
+++ b/q2_feature_table/tests/test_group.py
@@ -196,6 +196,21 @@ class TestGroup(unittest.TestCase):
         result = group(table, axis='sample', metadata=sample_mc, mode='sum')
         self.assertEqual(expected, result)
 
+    def test_group_to_single_id(self):
+        sample_mc = qiime2.MetadataCategory(
+            pd.Series(['all_samples', 'all_samples', 'all_samples'],
+                      index=['a', 'b', 'c']))
+
+        data = np.array([[1, 2, 3], [30, 20, 10]])
+        table = biom.Table(data, sample_ids=['a', 'b', 'c'],
+                           observation_ids=['x', 'y'])
+
+        expected = biom.Table(np.array([[6], [60]]),
+                              sample_ids=['all_samples'],
+                              observation_ids=['x', 'y'])
+        result = group(table, axis='sample', metadata=sample_mc, mode='sum')
+        self.assertEqual(expected, result)
+
     def test_empty(self):
         # Trusting that the code is sane enough to not invent a distinction
         # between feature and sample metadata where there is none
@@ -250,6 +265,18 @@ class TestGroup(unittest.TestCase):
 
         with self.assertRaisesRegex(ValueError, 'numeric'):
             group(table, axis='sample', metadata=sample_mc, mode='sum')
+
+    def test_empty_table(self):
+        mc = qiime2.MetadataCategory(
+            pd.Series(['a_new', 'b_new'], index=['a', 'b']))
+
+        table = biom.Table(np.array([[]]), sample_ids=[], observation_ids=[])
+
+        with self.assertRaisesRegex(ValueError, 'empty table'):
+            group(table, axis='sample', metadata=mc, mode='sum')
+
+        with self.assertRaisesRegex(ValueError, 'empty table'):
+            group(table, axis='feature', metadata=mc, mode='sum')
 
     def _shared_setup(self):
         sample_mc = qiime2.MetadataCategory(

--- a/q2_feature_table/tests/test_group.py
+++ b/q2_feature_table/tests/test_group.py
@@ -222,19 +222,19 @@ class TestGroup(unittest.TestCase):
         table = biom.Table(data, sample_ids=sample_ids,
                            observation_ids=['x', 'y'])
 
-        with self.assertRaisesRegex(ValueError, 'missing value.*{\'c\'}'):
+        with self.assertRaisesRegex(ValueError, 'missing.*value.*{\'c\'}'):
             group(table, axis='sample', metadata=sample_mc, mode='sum')
 
         nan_mc = qiime2.MetadataCategory(
             pd.Series(['a_new', float('nan'), 'a_new'], index=['a', 'b', 'c']))
 
-        with self.assertRaisesRegex(ValueError, 'missing value.*{\'b\'}'):
+        with self.assertRaisesRegex(ValueError, 'missing.*value.*{\'b\'}'):
             group(table, axis='sample', metadata=nan_mc, mode='sum')
 
         empty_str = qiime2.MetadataCategory(
             pd.Series(['', 'y_new'], index=['x', 'y']))
 
-        with self.assertRaisesRegex(ValueError, 'missing value.*{\'x\'}'):
+        with self.assertRaisesRegex(ValueError, 'missing.*value.*{\'x\'}'):
             group(table, axis='feature', metadata=empty_str,
                   mode='median-ceiling')
 
@@ -256,12 +256,27 @@ class TestGroup(unittest.TestCase):
         self.assertEqual(expected, result)
 
     def test_numeric(self):
-        sample_mc = qiime2.MetadataCategory(
-            pd.Series(['1', '2', '3'], index=['a', 'b', 'c']))
-
         data = np.array([[1, 2, 3], [30, 20, 10]])
         table = biom.Table(data, sample_ids=['a', 'b', 'c'],
                            observation_ids=['x', 'y'])
+
+        # ints
+        sample_mc = qiime2.MetadataCategory(
+            pd.Series(['1', '2', '3'], index=['a', 'b', 'c']))
+
+        with self.assertRaisesRegex(ValueError, 'numeric'):
+            group(table, axis='sample', metadata=sample_mc, mode='sum')
+
+        # floats
+        sample_mc = qiime2.MetadataCategory(
+            pd.Series(['1.1', '2.2', '3.3333'], index=['a', 'b', 'c']))
+
+        with self.assertRaisesRegex(ValueError, 'numeric'):
+            group(table, axis='sample', metadata=sample_mc, mode='sum')
+
+        # mixed
+        sample_mc = qiime2.MetadataCategory(
+            pd.Series(['0', '42', '4.2'], index=['a', 'b', 'c']))
 
         with self.assertRaisesRegex(ValueError, 'numeric'):
             group(table, axis='sample', metadata=sample_mc, mode='sum')

--- a/q2_feature_table/tests/test_group.py
+++ b/q2_feature_table/tests/test_group.py
@@ -211,7 +211,7 @@ class TestGroup(unittest.TestCase):
         result = group(table, axis='sample', metadata=sample_mc, mode='sum')
         self.assertEqual(expected, result)
 
-    def test_empty(self):
+    def test_empty_metadata_values(self):
         # Trusting that the code is sane enough to not invent a distinction
         # between feature and sample metadata where there is none
         sample_mc = qiime2.MetadataCategory(

--- a/q2_feature_table/tests/test_group.py
+++ b/q2_feature_table/tests/test_group.py
@@ -1,0 +1,360 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016-2017, QIIME 2 development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+
+import unittest
+
+import biom
+import qiime2
+import pandas as pd
+import numpy as np
+
+from q2_feature_table import group
+
+
+class TestGroup(unittest.TestCase):
+    def test_identity_groups(self):
+        # These map to the same values as before
+        sample_mc = qiime2.MetadataCategory(
+            pd.Series(['a', 'b', 'c'], index=['a', 'b', 'c']))
+        feature_mc = qiime2.MetadataCategory(
+            pd.Series(['x', 'y'], index=['x', 'y']))
+        table = biom.Table(np.array([[1, 2, 3], [30, 20, 10]]),
+                           sample_ids=sample_mc.to_series().index,
+                           observation_ids=feature_mc.to_series().index)
+
+        # Sample x Sum
+        result = group(table, axis='sample', metadata=sample_mc, mode='sum')
+        self.assertEqual(table, result)
+
+        # Sample x Mean
+        result = group(table, axis='sample', metadata=sample_mc,
+                       mode='mean-ceiling')
+        self.assertEqual(table, result)
+
+        # Sample x Median
+        result = group(table, axis='sample', metadata=sample_mc,
+                       mode='median-ceiling')
+        self.assertEqual(table, result)
+
+        # Feature x Sum
+        result = group(table, axis='feature', metadata=feature_mc, mode='sum')
+        self.assertEqual(table, result)
+
+        # Feature x Mean
+        result = group(table, axis='feature', metadata=feature_mc,
+                       mode='mean-ceiling')
+        self.assertEqual(table, result)
+
+        # Feature x Median
+        result = group(table, axis='feature', metadata=feature_mc,
+                       mode='median-ceiling')
+        self.assertEqual(table, result)
+
+    def test_one_to_one_rename(self):
+        sample_mc = qiime2.MetadataCategory(
+            pd.Series(['a_new', 'b_new', 'c_new'], index=['a', 'b', 'c']))
+        original_sample_ids = sample_mc.to_series().index
+        new_sample_ids = list(sample_mc.to_series())
+
+        feature_mc = qiime2.MetadataCategory(
+            pd.Series(['x_new', 'y_new'], index=['x', 'y']))
+        original_feature_ids = feature_mc.to_series().index
+        new_feature_ids = list(feature_mc.to_series())
+
+        data = np.array([[1, 2, 3], [30, 20, 10]])
+        table = biom.Table(data, sample_ids=original_sample_ids,
+                           observation_ids=original_feature_ids)
+
+        # Sample renames
+        expected = biom.Table(data, sample_ids=new_sample_ids,
+                              observation_ids=original_feature_ids)
+
+        # Sample x Sum
+        result = group(table, axis='sample', metadata=sample_mc, mode='sum')
+        self.assertEqual(expected, result)
+
+        # Sample X Mean
+        result = group(table, axis='sample', metadata=sample_mc,
+                       mode='mean-ceiling')
+        self.assertEqual(expected, result)
+
+        # Sample X Mean
+        result = group(table, axis='sample', metadata=sample_mc,
+                       mode='median-ceiling')
+        self.assertEqual(expected, result)
+
+        # Feature renames
+        expected = biom.Table(data, sample_ids=original_sample_ids,
+                              observation_ids=new_feature_ids)
+
+        # Feature X Sum
+        result = group(table, axis='feature', metadata=feature_mc, mode='sum')
+        self.assertEqual(expected, result)
+
+        # Feature X Mean
+        result = group(table, axis='feature', metadata=feature_mc,
+                       mode='mean-ceiling')
+        self.assertEqual(expected, result)
+
+        # Feature X Median
+        result = group(table, axis='feature', metadata=feature_mc,
+                       mode='median-ceiling')
+        self.assertEqual(expected, result)
+
+    def test_superset_feature_group(self):
+        feature_mc = qiime2.MetadataCategory(
+            pd.Series(['g0', 'g0', 'g1', 'g2', 'g1', 'g2', 'extra'],
+                      index=['a', 'b', 'c', 'd', 'e', 'f', 'g']))
+        data = np.array([
+            [1, 0, 0],
+            [1, 10, 10],
+            [0, 0, 100],
+            [5, 5, 5],
+            [0, 1, 100],
+            [7, 8, 9]])
+        # g is missing on purpose
+        table = biom.Table(data, sample_ids=['s1', 's2', 's3'],
+                           observation_ids=['a', 'b', 'c', 'd', 'e', 'f'])
+
+        expected = biom.Table(
+                np.array([[2, 10, 10], [0, 1, 200], [12, 13, 14]]),
+                sample_ids=['s1', 's2', 's3'],
+                observation_ids=['g0', 'g1', 'g2'])
+        result = group(table, axis='feature', metadata=feature_mc, mode='sum')
+        self.assertEqual(expected, result)
+
+    def test_superset_sample_group(self):
+        sample_mc = qiime2.MetadataCategory(
+            pd.Series(['g0', 'g1', 'g2', 'g0', 'g1', 'g2'],
+                      index=['s1', 's2', 's3', 's4', 's5', 's6']))
+        data = np.array([
+            [0, 1, 2, 3],
+            [10, 11, 12, 13],
+            [100, 110, 120, 130]])
+        table = biom.Table(data, sample_ids=['s1', 's2', 's4', 's5'],
+                           observation_ids=['x', 'y', 'z'])
+
+        expected = biom.Table(
+            np.array([[2, 4], [22, 24], [220, 240]]),
+            sample_ids=['g0', 'g1'],
+            observation_ids=['x', 'y', 'z'])
+
+        result = group(table, axis='sample', metadata=sample_mc, mode='sum')
+        self.assertEqual(expected, result)
+
+    def test_missing_feature_ids(self):
+        feature_mc = qiime2.MetadataCategory(
+            pd.Series(['g0', 'g1', 'g2', 'g1', 'g2', 'extra'],
+                      index=['a', 'c', 'd', 'e', 'f', 'g']))
+        data = np.array([
+            [1, 0, 0],
+            [1, 10, 10],
+            [0, 0, 100],
+            [5, 5, 5],
+            [0, 1, 100],
+            [7, 8, 9]])
+        # g is missing on purpose
+        table = biom.Table(data, sample_ids=['s1', 's2', 's3'],
+                           observation_ids=['a', 'b', 'c', 'd', 'e', 'f'])
+
+        with self.assertRaisesRegex(ValueError, 'metadata.*missing: {\'b\'}'):
+            group(table, axis='feature', metadata=feature_mc, mode='sum')
+
+    def test_missing_sample_ids(self):
+        sample_mc = qiime2.MetadataCategory(
+            pd.Series(['g0', 'g2', 'g0', 'g2'],
+                      index=['s1', 's3', 's4', 's6']))
+        data = np.array([
+            [0, 1, 2, 3],
+            [10, 11, 12, 13],
+            [100, 110, 120, 130]])
+        table = biom.Table(data, sample_ids=['s1', 's2', 's4', 's5'],
+                           observation_ids=['x', 'y', 'z'])
+
+        with self.assertRaisesRegex(ValueError, 'metadata.*missing:') as e:
+            group(table, axis='sample', metadata=sample_mc, mode='sum')
+
+        self.assertIn('s2', str(e.exception))
+        self.assertIn('s5', str(e.exception))
+
+    def test_reorder(self):
+        sample_mc = qiime2.MetadataCategory(
+            pd.Series(['c', 'b', 'a'], index=['c', 'b', 'a']))
+
+        data = np.array([[1, 2, 3], [30, 20, 10]])
+        table = biom.Table(data, sample_ids=['a', 'b', 'c'],
+                           observation_ids=['x', 'y'])
+
+        expected = biom.Table(np.array([[3, 2, 1], [10, 20, 30]]),
+                              sample_ids=['c', 'b', 'a'],
+                              observation_ids=['x', 'y'])
+        result = group(table, axis='sample', metadata=sample_mc, mode='sum')
+        self.assertEqual(expected, result)
+
+    def test_empty(self):
+        # Trusting that the code is sane enough to not invent a distinction
+        # between feature and sample metadata where there is none
+        sample_mc = qiime2.MetadataCategory(
+            pd.Series(['a_new', 'a_new', None], index=['a', 'b', 'c']))
+        sample_ids = sample_mc.to_series().index
+
+        data = np.array([[1, 2, 3], [30, 20, 10]])
+        table = biom.Table(data, sample_ids=sample_ids,
+                           observation_ids=['x', 'y'])
+
+        with self.assertRaisesRegex(ValueError, 'missing value.*{\'c\'}'):
+            group(table, axis='sample', metadata=sample_mc, mode='sum')
+
+        nan_mc = qiime2.MetadataCategory(
+            pd.Series(['a_new', float('nan'), 'a_new'], index=['a', 'b', 'c']))
+
+        with self.assertRaisesRegex(ValueError, 'missing value.*{\'b\'}'):
+            group(table, axis='sample', metadata=nan_mc, mode='sum')
+
+        empty_str = qiime2.MetadataCategory(
+            pd.Series(['', 'y_new'], index=['x', 'y']))
+
+        with self.assertRaisesRegex(ValueError, 'missing value.*{\'x\'}'):
+            group(table, axis='feature', metadata=empty_str,
+                  mode='median-ceiling')
+
+    def test_empty_only_in_superset(self):
+        # Trusting that the code is sane enough to not invent a distinction
+        # between feature and sample metadata where there is none
+        sample_mc = qiime2.MetadataCategory(
+            pd.Series(['a_new', 'a_new', 'b_new', None],
+                      index=['a', 'b', 'c', 'd']))
+
+        data = np.array([[1, 2, 3], [30, 20, 10]])
+        table = biom.Table(data, sample_ids=['a', 'b', 'c'],
+                           observation_ids=['x', 'y'])
+        expected = biom.Table(np.array([[2, 3], [25, 10]]),
+                              sample_ids=['a_new', 'b_new'],
+                              observation_ids=['x', 'y'])
+        result = group(table, axis='sample', metadata=sample_mc,
+                       mode='mean-ceiling')
+        self.assertEqual(expected, result)
+
+    def test_numeric(self):
+        sample_mc = qiime2.MetadataCategory(
+            pd.Series(['1', '2', '3'], index=['a', 'b', 'c']))
+
+        data = np.array([[1, 2, 3], [30, 20, 10]])
+        table = biom.Table(data, sample_ids=['a', 'b', 'c'],
+                           observation_ids=['x', 'y'])
+
+        with self.assertRaisesRegex(ValueError, 'numeric'):
+            group(table, axis='sample', metadata=sample_mc, mode='sum')
+
+    def _shared_setup(self):
+        sample_mc = qiime2.MetadataCategory(
+            pd.Series(['treatment', 'treatment', 'control', 'other',
+                       'control', 'other', 'other'],
+                      index=['a', 'b', 'c', 'd',
+                             'e', 'f', 'g']))
+
+        feature_mc = qiime2.MetadataCategory(
+            pd.Series(['g0', 'g1', 'g1', 'g1', 'g0'],
+                      index=['v', 'w', 'x', 'y', 'z']))
+
+        data = np.array([
+            # t   t   c    o     c    o   o
+            # a   b   c    d     e    f   g
+            [0,  0,  0,  0,   1,    0,   2],    # v  g0
+            [10, 10, 10, 10,  10,   100, 1],    # w  g1
+            [12, 3,  14, 0,   0,    3,   34],   # x  g1
+            [1,  1,  1,  1,   1,    1,   1],    # y  g1
+            [0,  1,  11, 111, 1111, 20,  20]])  # z  g0
+
+        table = biom.Table(data, sample_ids=sample_mc.to_series().index,
+                           observation_ids=feature_mc.to_series().index)
+
+        return sample_mc, feature_mc, table
+
+    def test_feature_sum(self):
+        sample_mc, feature_mc, table = self._shared_setup()
+        expected = biom.Table(
+            np.array([[0, 1, 11, 111, 1112, 20, 22],
+                      [23, 14, 25, 11, 11, 104, 36]]),
+            sample_ids=sample_mc.to_series().index,
+            observation_ids=['g0', 'g1'])
+
+        result = group(table, axis='feature', metadata=feature_mc, mode='sum')
+        self.assertEqual(expected, result)
+
+    def test_feature_mean_ceiling(self):
+        sample_mc, feature_mc, table = self._shared_setup()
+        expected = biom.Table(
+            np.array([[0, 1, 6, 56, 556, 10, 11],
+                      [8, 5, 9, 4, 4, 35, 12]]),
+            sample_ids=sample_mc.to_series().index,
+            observation_ids=['g0', 'g1'])
+
+        result = group(table, axis='feature', metadata=feature_mc,
+                       mode='mean-ceiling')
+        self.assertEqual(expected, result)
+
+    def test_feature_median_ceiling(self):
+        sample_mc, feature_mc, table = self._shared_setup()
+        expected = biom.Table(
+            np.array([[0, 1, 6, 56, 556, 10, 11],
+                      [10, 3, 10, 1, 1, 3, 1]]),
+            sample_ids=sample_mc.to_series().index,
+            observation_ids=['g0', 'g1'])
+
+        result = group(table, axis='feature', metadata=feature_mc,
+                       mode='median-ceiling')
+        self.assertEqual(expected, result)
+
+    def test_sample_sum(self):
+        sample_mc, feature_mc, table = self._shared_setup()
+        expected = biom.Table(
+            np.array([[0, 1, 2],
+                      [20, 20, 111],
+                      [15, 14, 37],
+                      [2, 2, 3],
+                      [1, 1122, 151]]),
+            sample_ids=['treatment', 'control', 'other'],
+            observation_ids=feature_mc.to_series().index)
+
+        result = group(table, axis='sample', metadata=sample_mc, mode='sum')
+        self.assertEqual(expected, result)
+
+    def test_sample_mean_ceiling(self):
+        sample_mc, feature_mc, table = self._shared_setup()
+        expected = biom.Table(
+            np.array([[0, 1, 1],
+                      [10, 10, 37],
+                      [8, 7, 13],
+                      [1, 1, 1],
+                      [1, 561, 51]]),
+            sample_ids=['treatment', 'control', 'other'],
+            observation_ids=feature_mc.to_series().index)
+
+        result = group(table, axis='sample', metadata=sample_mc,
+                       mode='mean-ceiling')
+        self.assertEqual(expected, result)
+
+    def test_sample_median_ceiling(self):
+        sample_mc, feature_mc, table = self._shared_setup()
+        expected = biom.Table(
+            np.array([[0, 1, 0],
+                      [10, 10, 10],
+                      [8, 7, 3],
+                      [1, 1, 1],
+                      [1, 561, 20]]),
+            sample_ids=['treatment', 'control', 'other'],
+            observation_ids=feature_mc.to_series().index)
+
+        result = group(table, axis='sample', metadata=sample_mc,
+                       mode='median-ceiling')
+        self.assertEqual(expected, result)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/q2_feature_table/tests/test_group.py
+++ b/q2_feature_table/tests/test_group.py
@@ -290,8 +290,8 @@ class TestGroup(unittest.TestCase):
                       index=['v', 'w', 'x', 'y', 'z']))
 
         data = np.array([
-            # t   t   c    o     c    o   o
-            # a   b   c    d     e    f   g
+            # t  t   c   o    c     o    o
+            # a  b   c   d    e     f    g
             [0,  0,  0,  0,   1,    0,   2],    # v  g0
             [10, 10, 10, 10,  10,   100, 1],    # w  g1
             [12, 3,  14, 0,   0,    3,   34],   # x  g1


### PR DESCRIPTION
This allows you to group a feature-table using a metadata category which
maps existing ids into new bins. This can be done on either axis of the
table.

fixes #86