### PR TITLE
Fixes #129

### DIFF
--- a/q2_feature_table/plugin_setup.py
+++ b/q2_feature_table/plugin_setup.py
@@ -35,7 +35,7 @@ plugin = Plugin(
 plugin.methods.register_function(
     function=q2_feature_table.rarefy,
     inputs={'table': FeatureTable[Frequency]},
-    parameters={'sampling_depth': Int},
+    parameters={'sampling_depth': Int % Range(1, None)},
     outputs=[('rarefied_table', FeatureTable[Frequency])],
     input_descriptions={'table': 'The feature table to be rarefied.'},
     parameter_descriptions={


### PR DESCRIPTION
Sets an integer `Range` on sampling depth. I was not sure if and how to add a unit test for this as I believe this is controlled at plugin method registration. Below is the output I receive now:

```bash
(qiime2-2017.8) $ qiime feature-table rarefy --i-table table.qza --o-rarefied-table test --p-sampling-depth 5
Saved FeatureTable[Frequency] to: test.qza
(qiime2-2017.8.redux) $ qiime feature-table rarefy --i-table table.qza --o-rarefied-table test --p-sampling-depth 0
Usage: qiime feature-table rarefy [OPTIONS]

Error: Invalid value for "--p-sampling-depth": 0 is smaller than the minimum valid value 1.
(qiime2-2017.8.redux) $ qiime feature-table rarefy --i-table table.qza --o-rarefied-table test --p-sampling-depth -1
Usage: qiime feature-table rarefy [OPTIONS]

Error: Invalid value for "--p-sampling-depth": -1 is smaller than the minimum valid value 1.
```