### PR TITLE
BLD: set the minimum BIOM version 2.1.6.

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - python 3.5*
     - setuptools
     - scikit-bio
-    - biom-format >=2.1.5,<2.2.0
+    - biom-format >=2.1.6,<2.2.0
     - h5py
     - seaborn
     - numpy


### PR DESCRIPTION
As of this commit, this repository does not explicitly require 2.1.6.
However, we are issuing this minimum version change as to implicitly
take advantage of the bug fixes, performance improvements, and to expose
API expansions (which may trigger refactors).