### PR TITLE
BUG: Disable feature freq. rugplot

### DIFF
--- a/q2_feature_table/_summarize/_visualizer.py
+++ b/q2_feature_table/_summarize/_visualizer.py
@@ -81,7 +81,7 @@ def summarize(output_dir: str, table: biom.Table,
         table, axis='observation')
     if number_of_features > 1:
         feature_frequencies_ax = sns.distplot(feature_frequencies, kde=False,
-                                              rug=True)
+                                              rug=False)
         feature_frequencies_ax.set_xlabel('Frequency per feature')
         feature_frequencies_ax.set_ylabel('Number of features')
         feature_frequencies_ax.set_xscale('log')


### PR DESCRIPTION
Fixes #122 

On a test table with 65k features, this brought the runtime down to ~25 seconds, from ~35 minutes previously. The bottleneck appears to be matplotlib's rendering of the rugplot, so by disabling, we get a bit of performance gain more or less for free. The data is still available as a delimited download in the viz, so if users are interested in more complex figures, they have the data available to make it happen!