### PR TITLE
PERF: prefer Table.concat over Table.merge

### DIFF
--- a/q2_feature_table/_merge.py
+++ b/q2_feature_table/_merge.py
@@ -11,16 +11,16 @@ import pandas as pd
 import collections
 
 
+def overlap_methods():
+    return ('error_on_overlapping_sample', 'error_on_overlapping_feature',
+            'sum')
+
+
 def _get_overlapping(tables, axis):
     ids = collections.Counter()
     for table in tables:
         ids.update(table.ids(axis=axis))
     return {e for e, c in ids.items() if c > 1}
-
-
-def overlap_methods():
-    return ('error_on_overlapping_sample', 'error_on_overlapping_feature',
-            'sum')
 
 
 def merge(tables: biom.Table,

--- a/q2_feature_table/_merge.py
+++ b/q2_feature_table/_merge.py
@@ -31,14 +31,14 @@ def merge(tables: biom.Table,
     if overlap_method == 'error_on_overlapping_sample':
         try:
             return tables[0].concat(tables[1:], 'sample')
-        except biom.DisjointIDError:
+        except biom.exception.DisjointIDError:
             overlapping = _get_overlapping(tables, 'sample')
             raise ValueError('Same samples are present in some of the '
                              'provided tables: %s' % ', '.join(overlapping))
     elif overlap_method == 'error_on_overlapping_feature':
         try:
             return tables[0].concat(tables[1:], 'observation')
-        except biom.DisjointIDError:
+        except biom.exception.DisjointIDError:
             overlapping = _get_overlapping(tables, 'observation')
             raise ValueError('Same features are present in some of the '
                              'provided tables: %s' % ', '.join(overlapping))

--- a/q2_feature_table/tests/test_merge.py
+++ b/q2_feature_table/tests/test_merge.py
@@ -11,11 +11,12 @@ import unittest
 import skbio
 import numpy as np
 from biom.table import Table
+import biom.exception
 import pandas as pd
 import pandas.util.testing as pdt
 
 from q2_feature_table import merge, merge_seqs, merge_taxa
-from q2_feature_table._merge import _merge_feature_data, _get_overlapping
+from q2_feature_table._merge import _merge_feature_data
 
 
 class MergeTableTests(unittest.TestCase):
@@ -62,7 +63,8 @@ class MergeTableTests(unittest.TestCase):
         t2 = Table(np.array([[0, 2, 6], [2, 2, 4]]),
                    ['O1', 'O3'],
                    ['S4', 'S5', 'S6'])
-        with self.assertRaisesRegex(ValueError, 'features are present'):
+        with self.assertRaisesRegex(biom.exception.DisjointIDError,
+                                    'IDs are not disjoint'):
             merge([t1, t2], 'error_on_overlapping_feature')
 
     def test_valid_overlapping_sample_ids(self):
@@ -86,7 +88,8 @@ class MergeTableTests(unittest.TestCase):
         t2 = Table(np.array([[0, 2, 6], [2, 2, 4]]),
                    ['O1', 'O3'],
                    ['S1', 'S5', 'S6'])
-        with self.assertRaisesRegex(ValueError, 'samples.*S1'):
+        with self.assertRaisesRegex(biom.exception.DisjointIDError,
+                                    'IDs are not disjoint'):
             merge([t1, t2])
 
     def test_invalid_overlap_method(self):
@@ -166,51 +169,6 @@ class MergeTableTests(unittest.TestCase):
                     ['O1', 'O2', 'O3'],
                     ['S1', 'S2', 'S3', 'S4', 'S5', 'S6'])
         self.assertEqual(obs, exp)
-
-
-class UtilTests(unittest.TestCase):
-
-    def test_get_overlapping(self):
-        t1 = Table(np.array([[0, 1, 3], [1, 1, 2]]),
-                   ['O1', 'O2'], ['S1', 'S2', 'S3'])
-        t2 = Table(np.array([[0, 2, 6], [2, 2, 4]]),
-                   ['O1', 'O3'], ['S1', 'S5', 'S6'])
-        # samples
-        obs = _get_overlapping([t1, t2], 'sample')
-        self.assertEqual(set(['S1']), obs)
-
-        # features
-        obs = _get_overlapping([t1, t2], 'observation')
-        self.assertEqual(set(['O1']), obs)
-
-    def test_get_overlapping_no_overlap(self):
-        t1 = Table(np.array([[0, 1, 3], [1, 1, 2]]),
-                   ['O1', 'O2'], ['S1', 'S2', 'S3'])
-        t2 = Table(np.array([[0, 2, 6], [2, 2, 4]]),
-                   ['O3', 'O4'], ['S4', 'S5', 'S6'])
-        # samples
-        obs = _get_overlapping([t1, t2], 'sample')
-        self.assertEqual(set(), obs)
-
-        # features
-        obs = _get_overlapping([t1, t2], 'observation')
-        self.assertEqual(set(), obs)
-
-    def test_get_overlapping_multiple(self):
-        t1 = Table(np.array([[0, 1, 3], [1, 1, 2]]),
-                   ['O1', 'O2'], ['S1', 'S2', 'S3'])
-        t2 = Table(np.array([[0, 2, 6], [2, 2, 4]]),
-                   ['O1', 'O3'], ['S1', 'S5', 'S6'])
-        t3 = Table(np.array([[3, 3, 1], [0, 2, 1]]),
-                   ['O1', 'O2'], ['S1', 'S3', 'S6'])
-
-        # samples
-        obs = _get_overlapping([t1, t2, t3], 'sample')
-        self.assertEqual({'S1', 'S3', 'S6'}, obs)
-
-        # features
-        obs = _get_overlapping([t1, t2, t3], 'observation')
-        self.assertEqual({'O1', 'O2'}, obs)
 
 
 class MergeFeatureDataTests(unittest.TestCase):

--- a/q2_feature_table/tests/test_merge.py
+++ b/q2_feature_table/tests/test_merge.py
@@ -86,7 +86,7 @@ class MergeTableTests(unittest.TestCase):
         t2 = Table(np.array([[0, 2, 6], [2, 2, 4]]),
                    ['O1', 'O3'],
                    ['S1', 'S5', 'S6'])
-        with self.assertRaisesRegex(ValueError, 'samples are present'):
+        with self.assertRaisesRegex(ValueError, 'samples.*S1'):
             merge([t1, t2])
 
     def test_invalid_overlap_method(self):
@@ -168,6 +168,51 @@ class MergeTableTests(unittest.TestCase):
         self.assertEqual(obs, exp)
 
 
+class UtilTests(unittest.TestCase):
+
+    def test_get_overlapping(self):
+        t1 = Table(np.array([[0, 1, 3], [1, 1, 2]]),
+                   ['O1', 'O2'], ['S1', 'S2', 'S3'])
+        t2 = Table(np.array([[0, 2, 6], [2, 2, 4]]),
+                   ['O1', 'O3'], ['S1', 'S5', 'S6'])
+        # samples
+        obs = _get_overlapping([t1, t2], 'sample')
+        self.assertEqual(set(['S1']), obs)
+
+        # features
+        obs = _get_overlapping([t1, t2], 'observation')
+        self.assertEqual(set(['O1']), obs)
+
+    def test_get_overlapping_no_overlap(self):
+        t1 = Table(np.array([[0, 1, 3], [1, 1, 2]]),
+                   ['O1', 'O2'], ['S1', 'S2', 'S3'])
+        t2 = Table(np.array([[0, 2, 6], [2, 2, 4]]),
+                   ['O3', 'O4'], ['S4', 'S5', 'S6'])
+        # samples
+        obs = _get_overlapping([t1, t2], 'sample')
+        self.assertEqual(set(), obs)
+
+        # features
+        obs = _get_overlapping([t1, t2], 'observation')
+        self.assertEqual(set(), obs)
+
+    def test_get_overlapping_multiple(self):
+        t1 = Table(np.array([[0, 1, 3], [1, 1, 2]]),
+                   ['O1', 'O2'], ['S1', 'S2', 'S3'])
+        t2 = Table(np.array([[0, 2, 6], [2, 2, 4]]),
+                   ['O1', 'O3'], ['S1', 'S5', 'S6'])
+        t3 = Table(np.array([[3, 3, 1], [0, 2, 1]]),
+                   ['O1', 'O2'], ['S1', 'S3', 'S6'])
+
+        # samples
+        obs = _get_overlapping([t1, t2, t3], 'sample')
+        self.assertEqual({'S1', 'S3', 'S6'}, obs)
+
+        # features
+        obs = _get_overlapping([t1, t2, t3], 'observation')
+        self.assertEqual({'O1', 'O2'}, obs)
+
+
 class MergeFeatureDataTests(unittest.TestCase):
     def test_merge_single(self):
         d = pd.Series(['ACGT', 'ACCT'], index=['f1', 'f2'])
@@ -236,50 +281,6 @@ class MergeFeatureSequenceTests(unittest.TestCase):
                          skbio.DNA('ACCA', metadata={'id': 'wxy'})],
                         index=['f1', 'f2', 'f3'])
         pdt.assert_series_equal(obs, exp)
-
-
-class UtilTests(unittest.TestCase):
-    def test_get_overlapping(self):
-        t1 = Table(np.array([[0, 1, 3], [1, 1, 2]]),
-                   ['O1', 'O2'], ['S1', 'S2', 'S3'])
-        t2 = Table(np.array([[0, 2, 6], [2, 2, 4]]),
-                   ['O1', 'O3'], ['S1', 'S5', 'S6'])
-        # samples
-        obs = _get_overlapping([t1, t2], 'sample')
-        self.assertEqual(set(['S1']), obs)
-
-        # features
-        obs = _get_overlapping([t1, t2], 'observation')
-        self.assertEqual(set(['O1']), obs)
-
-    def test_get_overlapping_no_overlap(self):
-        t1 = Table(np.array([[0, 1, 3], [1, 1, 2]]),
-                   ['O1', 'O2'], ['S1', 'S2', 'S3'])
-        t2 = Table(np.array([[0, 2, 6], [2, 2, 4]]),
-                   ['O3', 'O4'], ['S4', 'S5', 'S6'])
-        # samples
-        obs = _get_overlapping([t1, t2], 'sample')
-        self.assertEqual(set(), obs)
-
-        # features
-        obs = _get_overlapping([t1, t2], 'observation')
-        self.assertEqual(set(), obs)
-
-    def test_get_overlapping_multiple(self):
-        t1 = Table(np.array([[0, 1, 3], [1, 1, 2]]),
-                   ['O1', 'O2'], ['S1', 'S2', 'S3'])
-        t2 = Table(np.array([[0, 2, 6], [2, 2, 4]]),
-                   ['O1', 'O3'], ['S1', 'S5', 'S6'])
-        t3 = Table(np.array([[3, 3, 1], [0, 2, 1]]),
-                   ['O1', 'O2'], ['S1', 'S3', 'S6'])
-
-        # samples
-        obs = _get_overlapping([t1, t2, t3], 'sample')
-        self.assertEqual({'S1', 'S3', 'S6'}, obs)
-
-        # features
-        obs = _get_overlapping([t1, t2, t3], 'observation')
-        self.assertEqual({'O1', 'O2'}, obs)
 
 
 class MergeFeatureTaxonomyTests(unittest.TestCase):

--- a/q2_feature_table/tests/test_merge.py
+++ b/q2_feature_table/tests/test_merge.py
@@ -11,12 +11,11 @@ import unittest
 import skbio
 import numpy as np
 from biom.table import Table
-import biom.exception
 import pandas as pd
 import pandas.util.testing as pdt
 
 from q2_feature_table import merge, merge_seqs, merge_taxa
-from q2_feature_table._merge import _merge_feature_data
+from q2_feature_table._merge import _merge_feature_data, _get_overlapping
 
 
 class MergeTableTests(unittest.TestCase):
@@ -63,8 +62,7 @@ class MergeTableTests(unittest.TestCase):
         t2 = Table(np.array([[0, 2, 6], [2, 2, 4]]),
                    ['O1', 'O3'],
                    ['S4', 'S5', 'S6'])
-        with self.assertRaisesRegex(biom.exception.DisjointIDError,
-                                    'IDs are not disjoint'):
+        with self.assertRaisesRegex(ValueError, 'features are present'):
             merge([t1, t2], 'error_on_overlapping_feature')
 
     def test_valid_overlapping_sample_ids(self):
@@ -88,8 +86,7 @@ class MergeTableTests(unittest.TestCase):
         t2 = Table(np.array([[0, 2, 6], [2, 2, 4]]),
                    ['O1', 'O3'],
                    ['S1', 'S5', 'S6'])
-        with self.assertRaisesRegex(biom.exception.DisjointIDError,
-                                    'IDs are not disjoint'):
+        with self.assertRaisesRegex(ValueError, 'samples are present'):
             merge([t1, t2])
 
     def test_invalid_overlap_method(self):
@@ -239,6 +236,50 @@ class MergeFeatureSequenceTests(unittest.TestCase):
                          skbio.DNA('ACCA', metadata={'id': 'wxy'})],
                         index=['f1', 'f2', 'f3'])
         pdt.assert_series_equal(obs, exp)
+
+
+class UtilTests(unittest.TestCase):
+    def test_get_overlapping(self):
+        t1 = Table(np.array([[0, 1, 3], [1, 1, 2]]),
+                   ['O1', 'O2'], ['S1', 'S2', 'S3'])
+        t2 = Table(np.array([[0, 2, 6], [2, 2, 4]]),
+                   ['O1', 'O3'], ['S1', 'S5', 'S6'])
+        # samples
+        obs = _get_overlapping([t1, t2], 'sample')
+        self.assertEqual(set(['S1']), obs)
+
+        # features
+        obs = _get_overlapping([t1, t2], 'observation')
+        self.assertEqual(set(['O1']), obs)
+
+    def test_get_overlapping_no_overlap(self):
+        t1 = Table(np.array([[0, 1, 3], [1, 1, 2]]),
+                   ['O1', 'O2'], ['S1', 'S2', 'S3'])
+        t2 = Table(np.array([[0, 2, 6], [2, 2, 4]]),
+                   ['O3', 'O4'], ['S4', 'S5', 'S6'])
+        # samples
+        obs = _get_overlapping([t1, t2], 'sample')
+        self.assertEqual(set(), obs)
+
+        # features
+        obs = _get_overlapping([t1, t2], 'observation')
+        self.assertEqual(set(), obs)
+
+    def test_get_overlapping_multiple(self):
+        t1 = Table(np.array([[0, 1, 3], [1, 1, 2]]),
+                   ['O1', 'O2'], ['S1', 'S2', 'S3'])
+        t2 = Table(np.array([[0, 2, 6], [2, 2, 4]]),
+                   ['O1', 'O3'], ['S1', 'S5', 'S6'])
+        t3 = Table(np.array([[3, 3, 1], [0, 2, 1]]),
+                   ['O1', 'O2'], ['S1', 'S3', 'S6'])
+
+        # samples
+        obs = _get_overlapping([t1, t2, t3], 'sample')
+        self.assertEqual({'S1', 'S3', 'S6'}, obs)
+
+        # features
+        obs = _get_overlapping([t1, t2, t3], 'observation')
+        self.assertEqual({'O1', 'O2'}, obs)
 
 
 class MergeFeatureTaxonomyTests(unittest.TestCase):


### PR DESCRIPTION
Modifies `q2_feature_table.merge` to prefer the use of `Table.concat` which is 1-2 orders magnitude faster than `Table.merge` with increasing performance gains as the number of tables to merge gets large. 