### PR TITLE
update biom version req. to 2.1.7

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - python 3.5*
     - setuptools
     - scikit-bio
-    - biom-format >=2.1.6,<2.2.0
+    - biom-format >=2.1.7,<2.2.0
     - h5py
     - seaborn
     - numpy


### PR DESCRIPTION
This PR changes the minimum required version of `biom` to accomodate another PR which will add a `with_replacement` option to the `rarefy` function.