### PR TITLE
DOC: BIOM citation

### DIFF
--- a/q2_feature_table/citations.bib
+++ b/q2_feature_table/citations.bib
@@ -1,3 +1,30 @@
+@Article{McDonald2012,
+author="McDonald, Daniel
+and Clemente, Jose C.
+and Kuczynski, Justin
+and Rideout, Jai Ram
+and Stombaugh, Jesse
+and Wendel, Doug
+and Wilke, Andreas
+and Huse, Susan
+and Hufnagle, John
+and Meyer, Folker
+and Knight, Rob
+and Caporaso, J. Gregory",
+title="The Biological Observation Matrix (BIOM) format or: how I learned to stop worrying and love the ome-ome",
+journal="GigaScience",
+year="2012",
+month="Jul",
+day="12",
+volume="1",
+number="1",
+pages="7",
+abstract="We present the Biological Observation Matrix (BIOM, pronounced ``biome'') format: a JSON-based file format for representing arbitrary observation by sample contingency tables with associated sample and observation metadata. As the number of categories of comparative omics data types (collectively, the ``ome-ome'') grows rapidly, a general format to represent and archive this data will facilitate the interoperability of existing bioinformatics tools and future meta-analyses.",
+issn="2047-217X",
+doi="10.1186/2047-217X-1-7",
+url="https://doi.org/10.1186/2047-217X-1-7"
+}
+
 @Article{Weiss2017,
 author="Weiss, Sophie and Xu, Zhenjiang Zech and Peddada, Shyamal and Amir, Amnon and Bittinger, Kyle and Gonzalez, Antonio and Lozupone, Catherine and Zaneveld, Jesse R. and V{\'a}zquez-Baeza, Yoshiki and Birmingham, Amanda and Hyde, Embriette R. and Knight, Rob",
 title="Normalization and microbial differential abundance strategies depend upon data characteristics",


### PR DESCRIPTION
The BIOM-Format citation wasn't included in the citations file. This pull request simply adds the .bib entry from GigaScience. This PR does not currently use the citation on any action as it wasn't clear to me where it should go. 