### PR TITLE
allow heatmap to not cluster on samples or features

### DIFF
--- a/q2_feature_table/_heatmap/_visualizer.py
+++ b/q2_feature_table/_heatmap/_visualizer.py
@@ -29,7 +29,7 @@ heatmap_choices = {
                'sokalsneath', 'sqeuclidean', 'yule'},
     'method': {'single', 'complete', 'average', 'weighted', 'centroid',
                'median', 'ward'},
-    'cluster': {'samples', 'features', 'both'},
+    'cluster': {'samples', 'features', 'both', 'none'},
     'color_scheme': {'Accent', 'Accent_r', 'Blues', 'Blues_r', 'BrBG',
                      'BrBG_r', 'BuGn', 'BuGn_r', 'BuPu', 'BuPu_r', 'CMRmap',
                      'CMRmap_r', 'Dark2', 'Dark2_r', 'GnBu', 'GnBu_r',
@@ -71,7 +71,8 @@ heatmap_choices = {
 
 _clustering_map = {'both': {'col_cluster': True, 'row_cluster': True},
                    'samples': {'col_cluster': False, 'row_cluster': True},
-                   'features': {'col_cluster': True, 'row_cluster': False}}
+                   'features': {'col_cluster': True, 'row_cluster': False},
+                   'none': {'col_cluster': False, 'row_cluster': False}}
 
 
 def _munge_metadata(metadata, table, cluster):

--- a/q2_feature_table/plugin_setup.py
+++ b/q2_feature_table/plugin_setup.py
@@ -469,8 +469,7 @@ plugin.visualizers.register_function(
         'method': 'Clustering methods exposed by seaborn (see http://seaborn.'
                   'pydata.org/generated/seaborn.clustermap.html#seaborn.clust'
                   'ermap for more detail).',
-        'cluster': 'Specify which axes to cluster. Option to cluster on '
-                   'samples, features, both or none',
+        'cluster': 'Specify which axes to cluster.',
         'color_scheme': 'The matplotlib colorscheme to generate the heatmap '
                         'with.',
     },

--- a/q2_feature_table/plugin_setup.py
+++ b/q2_feature_table/plugin_setup.py
@@ -469,7 +469,8 @@ plugin.visualizers.register_function(
         'method': 'Clustering methods exposed by seaborn (see http://seaborn.'
                   'pydata.org/generated/seaborn.clustermap.html#seaborn.clust'
                   'ermap for more detail).',
-        'cluster': 'Specify which axes to cluster.',
+        'cluster': 'Specify which axes to cluster. Option to cluster on '
+                   'samples, features, both or none',
         'color_scheme': 'The matplotlib colorscheme to generate the heatmap '
                         'with.',
     },

--- a/q2_feature_table/tests/test_heatmap.py
+++ b/q2_feature_table/tests/test_heatmap.py
@@ -100,6 +100,15 @@ class TestHeatmap(unittest.TestCase):
 
         self.assertBasicVizValidity(self.output_dir)
 
+    def test_no_cluster(self):
+        md = qiime2.CategoricalMetadataColumn(
+            pd.Series(['milo', 'summer', 'russ'], name='pet',
+                      index=pd.Index(['S1', 'S2', 'S3'], name='id')))
+
+        heatmap(self.output_dir, self.table, metadata=md, cluster='none')
+
+        self.assertBasicVizValidity(self.output_dir)
+
 
 class TestPrivateHelpers(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Fixes #173 

Updates: _heatmap options for clustering, options and docs for plugin, unit test for feature

---

Sample output with no clustering (`none` option).

![Example-none-Cluster](https://user-images.githubusercontent.com/19470970/55577634-e1028f00-56c8-11e9-9222-04129cc10120.png)
