### PR TITLE
annotate heatmap with feature metadata (e.g., taxonomy)

### DIFF
--- a/q2_feature_table/_heatmap/_visualizer.py
+++ b/q2_feature_table/_heatmap/_visualizer.py
@@ -97,16 +97,32 @@ def _munge_metadata(metadata, table, cluster):
     return table
 
 
+def _munge_feature_metadata(metadata, table, cluster):
+    metadata = metadata.filter_ids(table.columns)
+    column_name = metadata.name
+    metadata_df = metadata.to_dataframe()
+    # replace feature IDs with feature metadata annotations
+    table.columns = metadata_df.reindex(table.columns)[column_name].values
+    if cluster == 'samples':
+        table = table.reindex(sorted(table.columns), axis=1)
+    return table
+
+
 def heatmap(output_dir, table: pd.DataFrame,
-            metadata: qiime2.CategoricalMetadataColumn = None,
+            sample_metadata: qiime2.CategoricalMetadataColumn = None,
+            feature_metadata: qiime2.CategoricalMetadataColumn = None,
             normalize: bool = True, title: str = None,
             metric: str = 'euclidean', method: str = 'average',
             cluster: str = 'both', color_scheme: str = 'rocket') -> None:
     if table.empty:
         raise ValueError('Cannot visualize an empty table.')
 
-    if metadata is not None:
-        table = _munge_metadata(metadata, table, cluster)
+    if sample_metadata is not None:
+        table = _munge_metadata(sample_metadata, table, cluster)
+
+    # relabel feature table feature IDs with feature metadata column values
+    if feature_metadata is not None:
+        table = _munge_feature_metadata(feature_metadata, table, cluster)
 
     cbar_label = 'frequency'
     if normalize:

--- a/q2_feature_table/_heatmap/_visualizer.py
+++ b/q2_feature_table/_heatmap/_visualizer.py
@@ -75,7 +75,7 @@ _clustering_map = {'both': {'col_cluster': True, 'row_cluster': True},
                    'none': {'col_cluster': False, 'row_cluster': False}}
 
 
-def _munge_metadata(metadata, table, cluster):
+def _munge_sample_metadata(metadata, table, cluster):
     metadata = metadata.filter_ids(table.index)
     column_name = metadata.name
 
@@ -104,7 +104,7 @@ def _munge_feature_metadata(metadata, table, cluster):
     # replace feature IDs with feature metadata annotations
     table.columns = metadata_df.reindex(table.columns)[column_name].values
     if cluster == 'samples':
-        table = table.reindex(sorted(table.columns), axis=1)
+        table = table.sort_index(axis=1)
     return table
 
 
@@ -118,7 +118,7 @@ def heatmap(output_dir, table: pd.DataFrame,
         raise ValueError('Cannot visualize an empty table.')
 
     if sample_metadata is not None:
-        table = _munge_metadata(sample_metadata, table, cluster)
+        table = _munge_sample_metadata(sample_metadata, table, cluster)
 
     # relabel feature table feature IDs with feature metadata column values
     if feature_metadata is not None:

--- a/q2_feature_table/plugin_setup.py
+++ b/q2_feature_table/plugin_setup.py
@@ -440,7 +440,8 @@ plugin.visualizers.register_function(
         'table': FeatureTable[Frequency]
     },
     parameters={
-        'metadata': MetadataColumn[Categorical],
+        'sample_metadata': MetadataColumn[Categorical],
+        'feature_metadata': MetadataColumn[Categorical],
         'normalize': Bool,
         'title': Str,
         'metric': Str % Choices(q2_feature_table.heatmap_choices['metric']),
@@ -459,9 +460,14 @@ plugin.visualizers.register_function(
         'table': 'The feature table to visualize.'
     },
     parameter_descriptions={
-        'metadata': 'Annotate the sample IDs with these metadata values. '
-                    'When metadata is present and `cluster`=\'feature\', '
-                    'samples will be sorted by the metadata values.',
+        'sample_metadata': 'Annotate the sample IDs with these sample '
+                           'metadata values. When metadata is present and '
+                           '`cluster`=\'feature\', samples will be sorted by '
+                           'the metadata values.',
+        'feature_metadata': 'Annotate the feature IDs with these feature '
+                            'metadata values. When metadata is present and '
+                            '`cluster`=\'sample\', features will be sorted by '
+                            'the metadata values.',
         'normalize': 'Normalize the feature table by adding a psuedocount '
                      'of 1 and then taking the log10 of the table.',
         'title': 'Optional custom plot title.',


### PR DESCRIPTION
This will allow heatmaps to be labeled with feature metadata (e.g., taxonomy).

Contrast with taxa collapse: this will display individual ASVs annotated with whatever feature metadata you choose. So taxa are not collapsed.