### PR TITLE
Rename table

### DIFF
--- a/q2_feature_table/__init__.py
+++ b/q2_feature_table/__init__.py
@@ -14,7 +14,7 @@ from ._merge import (merge, merge_seqs, merge_taxa, overlap_methods)
 from ._filter import (filter_samples, filter_features, filter_seqs)
 from ._core_features import core_features
 from ._group import group
-from ._rename import relabel_ids
+from ._rename import rename_ids
 from ._heatmap import (heatmap, heatmap_choices)
 from ._version import get_versions
 
@@ -25,4 +25,4 @@ __all__ = ['rarefy', 'presence_absence', 'relative_frequency', 'transpose',
            'summarize', 'merge', 'merge_seqs', 'filter_samples',
            'filter_features', 'merge_taxa', 'tabulate_seqs', 'overlap_methods',
            'core_features', 'group', 'heatmap', 'heatmap_choices',
-           'filter_seqs', 'subsample', 'relabel_ids']
+           'filter_seqs', 'subsample', 'rename_ids']

--- a/q2_feature_table/__init__.py
+++ b/q2_feature_table/__init__.py
@@ -25,4 +25,4 @@ __all__ = ['rarefy', 'presence_absence', 'relative_frequency', 'transpose',
            'summarize', 'merge', 'merge_seqs', 'filter_samples',
            'filter_features', 'merge_taxa', 'tabulate_seqs', 'overlap_methods',
            'core_features', 'group', 'heatmap', 'heatmap_choices',
-           'filter_seqs', 'subsample', 'rename']
+           'filter_seqs', 'subsample', 'rename_samples']

--- a/q2_feature_table/__init__.py
+++ b/q2_feature_table/__init__.py
@@ -14,6 +14,7 @@ from ._merge import (merge, merge_seqs, merge_taxa, overlap_methods)
 from ._filter import (filter_samples, filter_features, filter_seqs)
 from ._core_features import core_features
 from ._group import group
+from ._rename import rename_samples
 from ._heatmap import (heatmap, heatmap_choices)
 from ._version import get_versions
 
@@ -24,4 +25,4 @@ __all__ = ['rarefy', 'presence_absence', 'relative_frequency', 'transpose',
            'summarize', 'merge', 'merge_seqs', 'filter_samples',
            'filter_features', 'merge_taxa', 'tabulate_seqs', 'overlap_methods',
            'core_features', 'group', 'heatmap', 'heatmap_choices',
-           'filter_seqs', 'subsample']
+           'filter_seqs', 'subsample', 'rename']

--- a/q2_feature_table/__init__.py
+++ b/q2_feature_table/__init__.py
@@ -14,7 +14,7 @@ from ._merge import (merge, merge_seqs, merge_taxa, overlap_methods)
 from ._filter import (filter_samples, filter_features, filter_seqs)
 from ._core_features import core_features
 from ._group import group
-from ._rename import rename_samples
+from ._rename import relabel_ids
 from ._heatmap import (heatmap, heatmap_choices)
 from ._version import get_versions
 
@@ -25,4 +25,4 @@ __all__ = ['rarefy', 'presence_absence', 'relative_frequency', 'transpose',
            'summarize', 'merge', 'merge_seqs', 'filter_samples',
            'filter_features', 'merge_taxa', 'tabulate_seqs', 'overlap_methods',
            'core_features', 'group', 'heatmap', 'heatmap_choices',
-           'filter_seqs', 'subsample', 'rename_samples']
+           'filter_seqs', 'subsample', 'relabel_ids']

--- a/q2_feature_table/_rename.py
+++ b/q2_feature_table/_rename.py
@@ -54,14 +54,17 @@ def _generate_new_names(old_ids, rename, strict, verbose=False):
 
 def rename_samples(table: biom.Table, 
                    metadata: qiime2.CategoricalMetadataColumn, 
+                   axis: str = 'sample',
                    strict: bool = False)\
                     -> biom.Table:
     
     rename = metadata.to_series()
-    old_ids = table.ids(axis='sample')
+    if axis == 'feature':
+        axis = 'observation'
+    old_ids = table.ids(axis=axis)
 
     new_ids = _generate_new_names(old_ids, rename, strict, False)
 
-    updated = table.update_ids(new_ids, axis='sample', inplace=False)
+    updated = table.update_ids(new_ids, axis=axis, inplace=False)
 
     return updated

--- a/q2_feature_table/_rename.py
+++ b/q2_feature_table/_rename.py
@@ -10,8 +10,6 @@ import warnings
 
 import biom
 import qiime2
-import numpy as np
-import pandas as pd
 
 
 def _generate_new_names(old_ids, rename, strict, verbose=False):
@@ -25,19 +23,21 @@ def _generate_new_names(old_ids, rename, strict, verbose=False):
                          'to combine multipel samples in the same table.')
     old_disjoint = list(set(old_ids) - set(rename.index))
     new_disjoint = list(set(rename.index) - set(old_ids))
-    
+
     if (len(old_disjoint) > 0) & strict:
         missing_rename = '\n    '.join(old_disjoint)
         raise ValueError(
             "There are ids in the table which do not have new names.\n"
-            "Either turn off strict mode or provide a remapping for all ids.\n"
+            "Either turn off strict mode or provide a remapping for all ids."
+            "\n"
             "The following ids are not mapped:\n"
             "    %s" % missing_rename
             )
     elif (len(old_disjoint) > 0) & verbose:
         missing_rename = '\n    '.join(old_disjoint)
         warnings.warn(UserWarning(
-            'There are ids in the original table which do not have new names.\n'
+            'There are ids in the original table which do not have new names.'
+            '\n'
             'The following ids will not be mapped:\n'
             '   %s' % missing_rename)
         )
@@ -48,6 +48,7 @@ def _generate_new_names(old_ids, rename, strict, verbose=False):
             'The following ids will not be mapped:\n'
             '   %s' % missing_rename)
         )
+
     new_ids = {id_: rename.to_dict().get(id_, id_) for id_ in old_ids}
     return new_ids
 
@@ -57,7 +58,7 @@ def rename_samples(table: biom.Table,
                    axis: str = 'sample',
                    strict: bool = False)\
                     -> biom.Table:
-    
+
     rename = metadata.to_series()
     if axis == 'feature':
         axis = 'observation'

--- a/q2_feature_table/_rename.py
+++ b/q2_feature_table/_rename.py
@@ -14,13 +14,13 @@ import qiime2
 
 def _generate_new_names(old_ids, rename, strict, verbose=False):
     """
-    Checks the list of samples ot be renamed
+    Checks the list of ids to be renamed
     """
     # all old ids need to be unique
     if (rename.value_counts() > 1).any():
         raise ValueError('All new ids must be unique.\n'
-                         'Try qiime feature-table group if you want '
-                         'to combine multipel samples in the same table.')
+                         'Try the group method in this plugin if you want '
+                         'to combine multiple ids in the same table.')
     old_disjoint = list(set(old_ids) - set(rename.index))
     new_disjoint = list(set(rename.index) - set(old_ids))
 
@@ -53,11 +53,11 @@ def _generate_new_names(old_ids, rename, strict, verbose=False):
     return new_ids
 
 
-def rename_samples(table: biom.Table,
-                   metadata: qiime2.CategoricalMetadataColumn,
-                   axis: str = 'sample',
-                   strict: bool = False)\
-                    -> biom.Table:
+def relabel_ids(table: biom.Table,
+                metadata: qiime2.CategoricalMetadataColumn,
+                axis: str = 'sample',
+                strict: bool = False)\
+                -> biom.Table:
 
     rename = metadata.to_series()
     if axis == 'feature':

--- a/q2_feature_table/_rename.py
+++ b/q2_feature_table/_rename.py
@@ -1,0 +1,67 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016-2020, QIIME 2 development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+
+import warnings
+
+import biom
+import qiime2
+import numpy as np
+import pandas as pd
+
+
+def _generate_new_names(old_ids, rename, strict, verbose=False):
+    """
+    Checks the list of samples ot be renamed
+    """
+    # all old ids need to be unique
+    if (rename.value_counts() > 1).any():
+        raise ValueError('All new ids must be unique.\n'
+                         'Try qiime feature-table group if you want '
+                         'to combine multipel samples in the same table.')
+    old_disjoint = list(set(old_ids) - set(rename.index))
+    new_disjoint = list(set(rename.index) - set(old_ids))
+    
+    if (len(old_disjoint) > 0) & strict:
+        missing_rename = '\n    '.join(old_disjoint)
+        raise ValueError(
+            "There are ids in the table which do not have new names.\n"
+            "Either turn off strict mode or provide a remapping for all ids.\n"
+            "The following ids are not mapped:\n"
+            "    %s" % missing_rename
+            )
+    elif (len(old_disjoint) > 0) & verbose:
+        missing_rename = '\n    '.join(old_disjoint)
+        warnings.warn(UserWarning(
+            'There are ids in the original table which do not have new names.\n'
+            'The following ids will not be mapped:\n'
+            '   %s' % missing_rename)
+        )
+    if (len(new_disjoint) > 0) & verbose:
+        missing_rename = '\n    '.join(new_disjoint)
+        warnings.warn(UserWarning(
+            'There are ids supplied for renaming that are not in the table.\n'
+            'The following ids will not be mapped:\n'
+            '   %s' % missing_rename)
+        )
+    new_ids = {id_: rename.to_dict().get(id_, id_) for id_ in old_ids}
+    return new_ids
+
+
+def rename_samples(table: biom.Table, 
+                   metadata: qiime2.CategoricalMetadataColumn, 
+                   strict: bool = False)\
+                    -> biom.Table:
+    
+    rename = metadata.to_series()
+    old_ids = table.ids(axis='sample')
+
+    new_ids = _generate_new_names(old_ids, rename, strict, False)
+
+    updated = table.update_ids(new_ids, axis='sample', inplace=False)
+
+    return updated

--- a/q2_feature_table/_rename.py
+++ b/q2_feature_table/_rename.py
@@ -19,7 +19,7 @@ def _generate_new_names(old_ids, rename, strict, verbose=False):
     # all old ids need to be unique
     if (rename.value_counts() > 1).any():
         raise ValueError('All new ids must be unique.\n'
-                         'Try the group method in this plugin if you want '
+                         'Try the "group" method in this plugin if you want '
                          'to combine multiple ids in the same table.')
     old_disjoint = list(set(old_ids) - set(rename.index))
     new_disjoint = list(set(rename.index) - set(old_ids))
@@ -27,18 +27,18 @@ def _generate_new_names(old_ids, rename, strict, verbose=False):
     if (len(old_disjoint) > 0) & strict:
         missing_rename = '\n    '.join(old_disjoint)
         raise ValueError(
-            "There are ids in the table which do not have new names.\n"
-            "Either turn off strict mode or provide a remapping for all ids."
-            "\n"
-            "The following ids are not mapped:\n"
-            "    %s" % missing_rename
+            'There are ids in the table which do not have new names.\n'
+            'Either turn off strict mode or provide new names for all ids.'
+            '\n'
+            'The following ids are missing new names:\n'
+            '    %s' % missing_rename
             )
     elif (len(old_disjoint) > 0) & verbose:
         missing_rename = '\n    '.join(old_disjoint)
         warnings.warn(UserWarning(
             'There are ids in the original table which do not have new names.'
             '\n'
-            'The following ids will not be mapped:\n'
+            'The following ids will not be included:\n'
             '   %s' % missing_rename)
         )
     if (len(new_disjoint) > 0) & verbose:
@@ -53,11 +53,11 @@ def _generate_new_names(old_ids, rename, strict, verbose=False):
     return new_ids
 
 
-def relabel_ids(table: biom.Table,
-                metadata: qiime2.CategoricalMetadataColumn,
-                axis: str = 'sample',
-                strict: bool = False)\
-                -> biom.Table:
+def rename_ids(table: biom.Table,
+               metadata: qiime2.CategoricalMetadataColumn,
+               axis: str = 'sample',
+               strict: bool = False)\
+               -> biom.Table:
 
     rename = metadata.to_series()
     if axis == 'feature':

--- a/q2_feature_table/_rename.py
+++ b/q2_feature_table/_rename.py
@@ -53,8 +53,8 @@ def _generate_new_names(old_ids, rename, strict, verbose=False):
     return new_ids
 
 
-def rename_samples(table: biom.Table, 
-                   metadata: qiime2.CategoricalMetadataColumn, 
+def rename_samples(table: biom.Table,
+                   metadata: qiime2.CategoricalMetadataColumn,
                    axis: str = 'sample',
                    strict: bool = False)\
                     -> biom.Table:

--- a/q2_feature_table/plugin_setup.py
+++ b/q2_feature_table/plugin_setup.py
@@ -244,6 +244,7 @@ plugin.methods.register_function(
     parameters={
         'metadata': MetadataColumn[Categorical],
         'strict': Bool,
+        'axis': Str % Choices({'sample', 'feature'})
         },
     outputs=[
         ('renamed_table', FeatureTable[Frequency | RelativeFrequency])
@@ -259,15 +260,16 @@ plugin.methods.register_function(
                    'the table must have a new name). Otherwise, only the '
                    'samples described in `metadata` will be renamed and '
                    'the others will keep their original names.'),
+        'axis': 'Along which axis to rename the data.'
 
     }, 
     output_descriptions={
         'renamed_table': ('A table which has new sample ids, where the ids '
                          'are replaced by values in the `metadata` column.')
     },
-    name="Rename samples in a table",
+    name="Renames samples or features in a table",
     description=('Renames the samples in a feature table using metadata to '
-                 'define the new sample IDs.')
+                 'define the new IDs.')
     )
 
 T = TypeMatch([Frequency, RelativeFrequency, PresenceAbsence, Composition])

--- a/q2_feature_table/plugin_setup.py
+++ b/q2_feature_table/plugin_setup.py
@@ -239,7 +239,7 @@ plugin.methods.register_function(
 T = TypeMatch([Frequency, RelativeFrequency, PresenceAbsence, Composition])
 
 plugin.methods.register_function(
-    function=q2_feature_table.relabel_ids,
+    function=q2_feature_table.rename_ids,
     inputs={
         'table': FeatureTable[T],
     },
@@ -255,22 +255,22 @@ plugin.methods.register_function(
         'table': 'The table to be renamed',
     },
     parameter_descriptions={
-        'metadata': ('A column defining the new names. Each old name must '
-                     'map to a unique new name.'' If strict mode is used, '
-                     'then every id in the original table must have a new id'),
-        'strict': ('Whether the naming needs to be strict (each sample in '
-                   'the table must have a new name). Otherwise, only the '
-                   'samples described in `metadata` will be renamed and '
-                   'the others will keep their original names.'),
-        'axis': 'Along which axis to rename the data.',
+        'metadata': 'A metadata column defining the new ids. Each original id '
+                    'must map to a new unique id. If strict mode is used, '
+                    'then every id in the original table must have a new id.',
+        'strict': 'Whether the naming needs to be strict (each id in '
+                  'the table must have a new id). Otherwise, only the '
+                  'ids described in `metadata` will be renamed and '
+                  'the others will keep their original id names.',
+        'axis': 'Along which axis to rename the ids.',
     },
     output_descriptions={
-        'renamed_table': ('A table which has new sample ids, where the ids '
-                          'are replaced by values in the `metadata` column.')
+        'renamed_table': 'A table which has new ids, where the ids are '
+                         'replaced by values in the `metadata` column.',
     },
-    name="Renames samples or features in a table",
-    description=('Renames the samples in a feature table using metadata to '
-                 'define the new IDs.')
+    name='Renames sample or feature ids in a table',
+    description='Renames the sample or feature ids in a feature table using '
+                'metadata to define the new ids.',
     )
 
 # TODO: constrain min/max frequency when optional is handled by typemap

--- a/q2_feature_table/plugin_setup.py
+++ b/q2_feature_table/plugin_setup.py
@@ -261,7 +261,7 @@ plugin.methods.register_function(
                    'samples described in `metadata` will be renamed and '
                    'the others will keep their original names.'),
         'axis': 'Along which axis to rename the data.',
-    }, 
+    },
     output_descriptions={
         'renamed_table': ('A table which has new sample ids, where the ids '
                           'are replaced by values in the `metadata` column.')

--- a/q2_feature_table/plugin_setup.py
+++ b/q2_feature_table/plugin_setup.py
@@ -236,10 +236,12 @@ plugin.methods.register_function(
                 "the data from the first will be propagated to the result."
 )
 
+T = TypeMatch([Frequency, RelativeFrequency, PresenceAbsence, Composition])
+
 plugin.methods.register_function(
-    function=q2_feature_table.rename_samples,
+    function=q2_feature_table.relabel_ids,
     inputs={
-        'table': FeatureTable[Frequency | RelativeFrequency],
+        'table': FeatureTable[T],
     },
     parameters={
         'metadata': MetadataColumn[Categorical],
@@ -247,7 +249,7 @@ plugin.methods.register_function(
         'axis': Str % Choices({'sample', 'feature'})
         },
     outputs=[
-        ('renamed_table', FeatureTable[Frequency | RelativeFrequency])
+        ('renamed_table', FeatureTable[T])
         ],
     input_descriptions={
         'table': 'The table to be renamed',
@@ -271,7 +273,6 @@ plugin.methods.register_function(
                  'define the new IDs.')
     )
 
-T = TypeMatch([Frequency, RelativeFrequency, PresenceAbsence, Composition])
 # TODO: constrain min/max frequency when optional is handled by typemap
 plugin.methods.register_function(
     function=q2_feature_table.filter_samples,

--- a/q2_feature_table/plugin_setup.py
+++ b/q2_feature_table/plugin_setup.py
@@ -260,12 +260,11 @@ plugin.methods.register_function(
                    'the table must have a new name). Otherwise, only the '
                    'samples described in `metadata` will be renamed and '
                    'the others will keep their original names.'),
-        'axis': 'Along which axis to rename the data.'
-
+        'axis': 'Along which axis to rename the data.',
     }, 
     output_descriptions={
         'renamed_table': ('A table which has new sample ids, where the ids '
-                         'are replaced by values in the `metadata` column.')
+                          'are replaced by values in the `metadata` column.')
     },
     name="Renames samples or features in a table",
     description=('Renames the samples in a feature table using metadata to '

--- a/q2_feature_table/plugin_setup.py
+++ b/q2_feature_table/plugin_setup.py
@@ -236,6 +236,40 @@ plugin.methods.register_function(
                 "the data from the first will be propagated to the result."
 )
 
+plugin.methods.register_function(
+    function=q2_feature_table.rename_samples,
+    inputs={
+        'table': FeatureTable[Frequency | RelativeFrequency],
+    },
+    parameters={
+        'metadata': MetadataColumn[Categorical],
+        'strict': Bool,
+        },
+    outputs=[
+        ('renamed_table', FeatureTable[Frequency | RelativeFrequency])
+        ],
+    input_descriptions={
+        'table': 'The table to be renamed',
+    },
+    parameter_descriptions={
+        'metadata': ('A column defining the new names. Each old name must '
+                     'map to a unique new name.'' If strict mode is used, '
+                     'then every id in the original table must have a new id'),
+        'strict': ('Whether the naming needs to be strict (each sample in '
+                   'the table must have a new name). Otherwise, only the '
+                   'samples described in `metadata` will be renamed and '
+                   'the others will keep their original names.'),
+
+    }, 
+    output_descriptions={
+        'renamed_table': ('A table which has new sample ids, where the ids '
+                         'are replaced by values in the `metadata` column.')
+    },
+    name="Rename samples in a table",
+    description=('Renames the samples in a feature table using metadata to '
+                 'define the new sample IDs.')
+    )
+
 T = TypeMatch([Frequency, RelativeFrequency, PresenceAbsence, Composition])
 # TODO: constrain min/max frequency when optional is handled by typemap
 plugin.methods.register_function(

--- a/q2_feature_table/tests/test_rename.py
+++ b/q2_feature_table/tests/test_rename.py
@@ -60,11 +60,11 @@ class TestRename(unittest.TestCase):
             new_names = \
                 _rename._generate_new_names(self.old_ids,
                                             self.name_map,
-                                            strict=False, 
+                                            strict=False,
                                             verbose=True)
         self.assertEqual(len(w), 2)
         self.assertTrue(isinstance(w[0].message, UserWarning))
-        self.assertEqual(str(w[0].message), 
+        self.assertEqual(str(w[0].message),
                          'There are ids in the original table which do not '
                          'have new names.\nThe following ids will not be '
                          'mapped:\n   S3')
@@ -106,15 +106,15 @@ class TestRename(unittest.TestCase):
             index=pd.Index(['01', '02'], name='feature-id'),
             columns=['sequence']
             ))
-        updated = _rename.rename_samples(table, 
+        updated = _rename.rename_samples(table,
                                          meta1.get_column('animal'))
         updated = _rename.rename_samples(updated,
                                          meta2.get_column('sequence'),
                                          axis='observation')
 
-        npt.assert_array_equal(np.array(updated.ids(axis='sample')), 
+        npt.assert_array_equal(np.array(updated.ids(axis='sample')),
                                np.array(['cat', 'rat', 'dog']))
-        npt.assert_array_equal(np.array(updated.ids(axis='observation')), 
+        npt.assert_array_equal(np.array(updated.ids(axis='observation')),
                                np.array(['CATCATCAT', 'WANTCAT']))
 
 

--- a/q2_feature_table/tests/test_rename.py
+++ b/q2_feature_table/tests/test_rename.py
@@ -36,8 +36,8 @@ class TestRename(unittest.TestCase):
             self.assertEqual(
                 str(cm.exception),
                 ('All new ids must be unique.\n'
-                 'Try qiime feature-table group if you want '
-                 'to combine multipel samples in the same table.')
+                 'Try the group method in this plugin if you want '
+                 'to combine multiple samples in the same table.')
                 )
 
     def test_generate_new_names_old_disjoint_strict(self):
@@ -106,11 +106,11 @@ class TestRename(unittest.TestCase):
             index=pd.Index(['01', '02'], name='feature-id'),
             columns=['sequence']
             ))
-        updated = _rename.rename_samples(table,
-                                         meta1.get_column('animal'))
-        updated = _rename.rename_samples(updated,
-                                         meta2.get_column('sequence'),
-                                         axis='feature')
+        updated = _rename.relabel_ids(table,
+                                      meta1.get_column('animal'))
+        updated = _rename.relabel_ids(updated,
+                                      meta2.get_column('sequence'),
+                                      axis='feature')
 
         npt.assert_array_equal(np.array(updated.ids(axis='sample')),
                                np.array(['cat', 'rat', 'dog']))

--- a/q2_feature_table/tests/test_rename.py
+++ b/q2_feature_table/tests/test_rename.py
@@ -110,7 +110,7 @@ class TestRename(unittest.TestCase):
                                          meta1.get_column('animal'))
         updated = _rename.rename_samples(updated,
                                          meta2.get_column('sequence'),
-                                         axis='observation')
+                                         axis='feature')
 
         npt.assert_array_equal(np.array(updated.ids(axis='sample')),
                                np.array(['cat', 'rat', 'dog']))

--- a/q2_feature_table/tests/test_rename.py
+++ b/q2_feature_table/tests/test_rename.py
@@ -95,16 +95,24 @@ class TestRename(unittest.TestCase):
         table = biom.Table(np.array([[0, 1, 2], [3, 4, 5]]),
                             observation_ids=['01', '02'],
                             sample_ids=['S1', 'S2', 'S3'])
-        meta = qiime2.Metadata(pd.DataFrame(
+        meta1 = qiime2.Metadata(pd.DataFrame(
             data=np.array([['cat'], ['rat'], ['dog']]),
             index=pd.Index(['S1', 'S2', 'S3'], name='sample-id'),
             columns=['animal']
             ))
-        updated = _rename.rename_samples(table, meta.get_column('animal'))
+        meta2 = qiime2.Metadata(pd.DataFrame(
+            data=[['CATCATCAT'], ['WANTCAT']],
+            index=pd.Index(['01', '02'], name='feature-id'),
+            columns=['sequence']
+            ))
+        updated = _rename.rename_samples(table, meta1.get_column('animal'))
+        updated = _rename.rename_samples(updated, meta2.get_column('sequence'),
+                                         axis='observation')
         
         npt.assert_array_equal(np.array(updated.ids(axis='sample')), 
                                np.array(['cat', 'rat', 'dog']))
-
+        npt.assert_array_equal(np.array(updated.ids(axis='observation')), 
+                               np.array(['CATCATCAT', 'WANTCAT']))
 
 
 if __name__ == "__main__":

--- a/q2_feature_table/tests/test_rename.py
+++ b/q2_feature_table/tests/test_rename.py
@@ -67,7 +67,7 @@ class TestRename(unittest.TestCase):
         self.assertEqual(str(w[0].message),
                          'There are ids in the original table which do not '
                          'have new names.\nThe following ids will not be '
-                         'mapped:\n   S3')
+                         'included:\n   S3')
         self.assertTrue(isinstance(w[1].message, UserWarning))
         self.assertEqual(str(w[1].message),
                          'There are ids supplied for renaming that are not in'
@@ -106,11 +106,11 @@ class TestRename(unittest.TestCase):
             index=pd.Index(['01', '02'], name='feature-id'),
             columns=['sequence']
             ))
-        updated = _rename.relabel_ids(table,
-                                      meta1.get_column('animal'))
-        updated = _rename.relabel_ids(updated,
-                                      meta2.get_column('sequence'),
-                                      axis='feature')
+        updated = _rename.rename_ids(table,
+                                     meta1.get_column('animal'))
+        updated = _rename.rename_ids(updated,
+                                     meta2.get_column('sequence'),
+                                     axis='feature')
 
         npt.assert_array_equal(np.array(updated.ids(axis='sample')),
                                np.array(['cat', 'rat', 'dog']))

--- a/q2_feature_table/tests/test_rename.py
+++ b/q2_feature_table/tests/test_rename.py
@@ -1,0 +1,111 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016-2020, QIIME 2 development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+
+import unittest
+import warnings
+
+import biom
+import qiime2
+import pandas as pd
+import numpy as np
+import numpy.testing as npt
+
+from q2_feature_table import _rename
+
+
+class TestRename(unittest.TestCase):
+    def setUp(self):
+        self.old_ids = ['S1', 'S2', 'S3']
+        self.name_map = pd.Series({'S1': 'S1_new', 
+                                   'S2': 'S2_new', 
+                                   'S4': 'S4_name'})
+        self.known = {'S1': 'S1_new', 'S2': 'S2_new', 'S3': 'S3'}
+
+    def test_generate_new_names_non_unique(self):
+        name_map = pd.Series({'S1': 'S2_new', 'S2': 'S2_new'})
+        with self.assertRaises(ValueError) as cm:
+            _rename._generate_new_names(self.old_ids, 
+                                        name_map, 
+                                        strict=True, 
+                                        verbose=False)
+            self.assertEqual(
+                str(cm.exception),
+                ('All new ids must be unique.\n'
+                 'Try qiime feature-table group if you want '
+                 'to combine multipel samples in the same table.')
+                )
+
+    def test_generate_new_names_old_disjoint_strict(self):
+        with self.assertRaises(ValueError) as cm:
+            _rename._generate_new_names(self.old_ids, self.name_map, 
+                                        strict=True, 
+                                        verbose=False)
+            self.assertEqual(
+                str(cm.exception),
+                ("There are ids in the table which do not have new names.\n"
+                 "Either turn off strict mode or provide a remapping for all ids.\n"
+                 "The following ids are not mapped:\n    S3")
+                )
+
+    def test_generate_new_names_verbose_warnings(self):
+        with warnings.catch_warnings(record=True) as w:
+            # Cause all warnings to always be triggered.
+            warnings.simplefilter("always")
+            new_names = \
+                _rename._generate_new_names(self.old_ids, 
+                                            self.name_map, 
+                                            strict=False, 
+                                            verbose=True)
+        self.assertEqual(len(w), 2)
+        self.assertTrue(isinstance(w[0].message, UserWarning))
+        self.assertEqual(str(w[0].message), 
+                         'There are ids in the original table which do not '
+                         'have new names.\nThe following ids will not be '
+                         'mapped:\n   S3')
+        self.assertTrue(isinstance(w[1].message, UserWarning))
+        self.assertEqual(str(w[1].message),
+                         'There are ids supplied for renaming that are not in'
+                         ' the table.\nThe following ids will not be mapped:'
+                         '\n   S4'
+                         )
+        self.assertEqual(new_names.keys(), self.known.keys())
+        for k, v in new_names.items():
+            self.assertEqual(v, self.known[k])
+
+    def test_generate_new_names_no_verbse(self):
+        with warnings.catch_warnings(record=True) as w:
+            # Cause all warnings to always be triggered.
+            warnings.simplefilter("always")
+            new_names = \
+                _rename._generate_new_names(self.old_ids, 
+                                            self.name_map, 
+                                            strict=False, 
+                                            verbose=False)
+        self.assertEqual(len(w), 0)
+        self.assertEqual(new_names.keys(), self.known.keys())
+        for k, v in new_names.items():
+            self.assertEqual(v, self.known[k])
+
+    def test_rename_samples(self):
+        table = biom.Table(np.array([[0, 1, 2], [3, 4, 5]]),
+                            observation_ids=['01', '02'],
+                            sample_ids=['S1', 'S2', 'S3'])
+        meta = qiime2.Metadata(pd.DataFrame(
+            data=np.array([['cat'], ['rat'], ['dog']]),
+            index=pd.Index(['S1', 'S2', 'S3'], name='sample-id'),
+            columns=['animal']
+            ))
+        updated = _rename.rename_samples(table, meta.get_column('animal'))
+        
+        npt.assert_array_equal(np.array(updated.ids(axis='sample')), 
+                               np.array(['cat', 'rat', 'dog']))
+
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/q2_feature_table/tests/test_rename.py
+++ b/q2_feature_table/tests/test_rename.py
@@ -21,17 +21,17 @@ from q2_feature_table import _rename
 class TestRename(unittest.TestCase):
     def setUp(self):
         self.old_ids = ['S1', 'S2', 'S3']
-        self.name_map = pd.Series({'S1': 'S1_new', 
-                                   'S2': 'S2_new', 
+        self.name_map = pd.Series({'S1': 'S1_new',
+                                   'S2': 'S2_new',
                                    'S4': 'S4_name'})
         self.known = {'S1': 'S1_new', 'S2': 'S2_new', 'S3': 'S3'}
 
     def test_generate_new_names_non_unique(self):
         name_map = pd.Series({'S1': 'S2_new', 'S2': 'S2_new'})
         with self.assertRaises(ValueError) as cm:
-            _rename._generate_new_names(self.old_ids, 
-                                        name_map, 
-                                        strict=True, 
+            _rename._generate_new_names(self.old_ids,
+                                        name_map,
+                                        strict=True,
                                         verbose=False)
             self.assertEqual(
                 str(cm.exception),
@@ -42,14 +42,15 @@ class TestRename(unittest.TestCase):
 
     def test_generate_new_names_old_disjoint_strict(self):
         with self.assertRaises(ValueError) as cm:
-            _rename._generate_new_names(self.old_ids, self.name_map, 
-                                        strict=True, 
+            _rename._generate_new_names(self.old_ids,
+                                        self.name_map,
+                                        strict=True,
                                         verbose=False)
             self.assertEqual(
                 str(cm.exception),
                 ("There are ids in the table which do not have new names.\n"
-                 "Either turn off strict mode or provide a remapping for all ids.\n"
-                 "The following ids are not mapped:\n    S3")
+                 "Either turn off strict mode or provide a remapping for "
+                 "all ids.\nThe following ids are not mapped:\n    S3")
                 )
 
     def test_generate_new_names_verbose_warnings(self):
@@ -57,8 +58,8 @@ class TestRename(unittest.TestCase):
             # Cause all warnings to always be triggered.
             warnings.simplefilter("always")
             new_names = \
-                _rename._generate_new_names(self.old_ids, 
-                                            self.name_map, 
+                _rename._generate_new_names(self.old_ids,
+                                            self.name_map,
                                             strict=False, 
                                             verbose=True)
         self.assertEqual(len(w), 2)
@@ -82,9 +83,9 @@ class TestRename(unittest.TestCase):
             # Cause all warnings to always be triggered.
             warnings.simplefilter("always")
             new_names = \
-                _rename._generate_new_names(self.old_ids, 
-                                            self.name_map, 
-                                            strict=False, 
+                _rename._generate_new_names(self.old_ids,
+                                            self.name_map,
+                                            strict=False,
                                             verbose=False)
         self.assertEqual(len(w), 0)
         self.assertEqual(new_names.keys(), self.known.keys())
@@ -93,8 +94,8 @@ class TestRename(unittest.TestCase):
 
     def test_rename_samples(self):
         table = biom.Table(np.array([[0, 1, 2], [3, 4, 5]]),
-                            observation_ids=['01', '02'],
-                            sample_ids=['S1', 'S2', 'S3'])
+                           observation_ids=['01', '02'],
+                           sample_ids=['S1', 'S2', 'S3'])
         meta1 = qiime2.Metadata(pd.DataFrame(
             data=np.array([['cat'], ['rat'], ['dog']]),
             index=pd.Index(['S1', 'S2', 'S3'], name='sample-id'),
@@ -105,10 +106,12 @@ class TestRename(unittest.TestCase):
             index=pd.Index(['01', '02'], name='feature-id'),
             columns=['sequence']
             ))
-        updated = _rename.rename_samples(table, meta1.get_column('animal'))
-        updated = _rename.rename_samples(updated, meta2.get_column('sequence'),
+        updated = _rename.rename_samples(table, 
+                                         meta1.get_column('animal'))
+        updated = _rename.rename_samples(updated,
+                                         meta2.get_column('sequence'),
                                          axis='observation')
-        
+
         npt.assert_array_equal(np.array(updated.ids(axis='sample')), 
                                np.array(['cat', 'rat', 'dog']))
         npt.assert_array_equal(np.array(updated.ids(axis='observation')), 


### PR DESCRIPTION
This addresses #223. It creates a renaming function based on a metadata column.

Outstanding:
There is theoretically a flag to add a warning (currently called "verbose") which would list off the samples that are being excluded/skipped. This can either be dropped, or needs to be hooked into the verbose flag in the plugin.