### PR TITLE
ENH: Added usage examples

### DIFF
--- a/q2_feature_table/examples.py
+++ b/q2_feature_table/examples.py
@@ -1,0 +1,55 @@
+import numpy as np
+from biom.table import Table
+
+from qiime2.sdk.usage import UsageAction, UsageInputs, UsageOutputNames
+from qiime2 import Artifact
+
+
+def ft1_factory():
+    return Artifact.import_data(
+        'FeatureTable[Frequency]',
+        Table(np.array([[0, 1, 3], [1, 1, 2]]),
+              ['O1', 'O2'],
+              ['S1', 'S2', 'S3']))
+
+
+def ft2_factory():
+    return Artifact.import_data(
+        'FeatureTable[Frequency]',
+        Table(np.array([[0, 2, 6], [2, 2, 4]]),
+              ['O1', 'O3'],
+              ['S4', 'S5', 'S6']))
+
+
+def ft3_factory():
+    return Artifact.import_data(
+        'FeatureTable[Frequency]',
+        Table(np.array([[0, 4, 9], [4, 4, 8]]),
+              ['O1', 'O4'],
+              ['S7', 'S8', 'S9']))
+
+
+def feature_table_merge_example(use):
+    feature_table1 = use.init_data('feature_table1', ft1_factory)
+    feature_table2 = use.init_data('feature_table2', ft2_factory)
+
+    use.action(
+        UsageAction(plugin_id='feature_table',
+                    action_id='merge'),
+        UsageInputs(tables=[feature_table1, feature_table2]),
+        UsageOutputNames(merged_table='merged_table'),
+    )
+
+
+def feature_table_merge_three_tables_example(use):
+    feature_table1 = use.init_data('feature_table1', ft1_factory)
+    feature_table2 = use.init_data('feature_table2', ft2_factory)
+    feature_table3 = use.init_data('feature_table3', ft3_factory)
+
+    use.action(
+        UsageAction(plugin_id='feature_table',
+                    action_id='merge'),
+        UsageInputs(tables=[feature_table1, feature_table2, feature_table3],
+                    overlap_method='sum'),
+        UsageOutputNames(merged_table='merged_table'),
+    )

--- a/q2_feature_table/examples.py
+++ b/q2_feature_table/examples.py
@@ -1,5 +1,13 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016-2020, QIIME 2 development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+
 import numpy as np
-from biom.table import Table
+from biom import Table
 
 from qiime2.sdk.usage import UsageAction, UsageInputs, UsageOutputNames
 from qiime2 import Artifact

--- a/q2_feature_table/plugin_setup.py
+++ b/q2_feature_table/plugin_setup.py
@@ -14,6 +14,8 @@ import q2_feature_table
 from q2_types.feature_table import (
     FeatureTable, Frequency, RelativeFrequency, PresenceAbsence, Composition)
 from q2_types.feature_data import FeatureData, Sequence, Taxonomy
+from .examples import (feature_table_merge_example,
+                       feature_table_merge_three_tables_example)
 
 citations = Citations.load('citations.bib', package='q2_feature_table')
 plugin = Plugin(
@@ -189,7 +191,10 @@ plugin.methods.register_function(
         'merged_table': ('The resulting merged feature table.'),
     },
     name="Combine multiple tables",
-    description="Combines feature tables using the `overlap_method` provided."
+    description="Combines feature tables using the `overlap_method` provided.",
+    examples={'feature_table_merge_exampe': feature_table_merge_example,
+              'feature_table_merge_three_tables_example':
+                  feature_table_merge_three_tables_example},
 )
 
 

--- a/q2_feature_table/plugin_setup.py
+++ b/q2_feature_table/plugin_setup.py
@@ -192,9 +192,8 @@ plugin.methods.register_function(
     },
     name="Combine multiple tables",
     description="Combines feature tables using the `overlap_method` provided.",
-    examples={'feature_table_merge_exampe': feature_table_merge_example,
-              'feature_table_merge_three_tables_example':
-                  feature_table_merge_three_tables_example},
+    examples={'basic': feature_table_merge_example,
+              'three_tables': feature_table_merge_three_tables_example},
 )
 
 

--- a/q2_feature_table/tests/test_examples.py
+++ b/q2_feature_table/tests/test_examples.py
@@ -1,0 +1,16 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016-2020, QIIME 2 development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+
+from qiime2.plugin.testing import TestPluginBase
+
+
+class TestUsageExample(TestPluginBase):
+    package = 'q2_feature_table.tests'
+
+    def test_usage_example_ft_merge(self):
+        self.execute_examples()

--- a/q2_feature_table/tests/test_examples.py
+++ b/q2_feature_table/tests/test_examples.py
@@ -12,5 +12,5 @@ from qiime2.plugin.testing import TestPluginBase
 class TestUsageExample(TestPluginBase):
     package = 'q2_feature_table.tests'
 
-    def test_usage_example_ft_merge(self):
+    def test_usage_examples(self):
         self.execute_examples()

--- a/q2_feature_table/tests/test_merge.py
+++ b/q2_feature_table/tests/test_merge.py
@@ -14,6 +14,7 @@ from biom.table import Table
 import pandas as pd
 import pandas.util.testing as pdt
 
+from qiime2.plugin.testing import TestPluginBase
 from q2_feature_table import merge, merge_seqs, merge_taxa
 from q2_feature_table._merge import _merge_feature_data, _get_overlapping
 
@@ -300,6 +301,13 @@ class MergeFeatureTaxonomyTests(unittest.TestCase):
             [('a;b;c;d', '1.0'), ('a;b;c;f', '0.7'), ('a;b;c;e', '1.0')],
             index=['f1', 'f2', 'f3'], columns=['Taxon', 'Confidence'])
         pdt.assert_frame_equal(obs, exp)
+
+
+class TestUsageExample(TestPluginBase):
+    package = 'q2_feature_table.tests'
+
+    def test_usage_example_ft_merge(self):
+        self.execute_examples()
 
 
 if __name__ == "__main__":

--- a/q2_feature_table/tests/test_merge.py
+++ b/q2_feature_table/tests/test_merge.py
@@ -14,7 +14,6 @@ from biom.table import Table
 import pandas as pd
 import pandas.util.testing as pdt
 
-from qiime2.plugin.testing import TestPluginBase
 from q2_feature_table import merge, merge_seqs, merge_taxa
 from q2_feature_table._merge import _merge_feature_data, _get_overlapping
 
@@ -301,13 +300,6 @@ class MergeFeatureTaxonomyTests(unittest.TestCase):
             [('a;b;c;d', '1.0'), ('a;b;c;f', '0.7'), ('a;b;c;e', '1.0')],
             index=['f1', 'f2', 'f3'], columns=['Taxon', 'Confidence'])
         pdt.assert_frame_equal(obs, exp)
-
-
-class TestUsageExample(TestPluginBase):
-    package = 'q2_feature_table.tests'
-
-    def test_usage_example_ft_merge(self):
-        self.execute_examples()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds two usage examples to this plugin:

1. The first is a merge example of two feature tables. The `UsageInput` accepts a list of tables to accomplish this action.

2. The second is a merge example of three feature tables. This example will accept an additional parameter `overlap_method='sum'`. Currently, the validation for `UsageInput` will not accept this parameter, so changes will be needed before merging.

The plugin setup was changed to accept the new functions that create the usage examples. More changes for plugin setup might be needed as more usage examples are added.

---

Blocked by https://github.com/qiime2/qiime2/pull/528