### PR TITLE
Added keep_zero_features option to filter-samples which addresses iss…

### DIFF
--- a/q2_feature_table/_filter.py
+++ b/q2_feature_table/_filter.py
@@ -32,7 +32,7 @@ _other_axis_map = {'sample': 'observation', 'observation': 'sample'}
 
 def _filter_table(table, min_frequency, max_frequency, min_nonzero,
                   max_nonzero, metadata, where, axis, exclude_ids=False,
-                  keep_zero_features=False):
+                  filter_opposite_axis=True):
     if min_frequency == 0 and max_frequency is None and min_nonzero == 0 and\
        max_nonzero is None and metadata is None and where is None and\
        exclude_ids is False:
@@ -56,7 +56,7 @@ def _filter_table(table, min_frequency, max_frequency, min_nonzero,
 
     # filter on the opposite axis to remove any entities that now have a
     # frequency of zero
-    if not keep_zero_features:
+    if filter_opposite_axis:
         filter_fn2 = _get_biom_filter_function(
             ids_to_keep=table.ids(axis=_other_axis_map[axis]), min_frequency=0,
             max_frequency=None, min_nonzero=1, max_nonzero=None)
@@ -68,13 +68,13 @@ def filter_samples(table: biom.Table, min_frequency: int = 0,
                    max_features: int = None,
                    metadata: qiime2.Metadata = None, where: str = None,
                    exclude_ids: bool = False,
-                   keep_zero_features: bool = False)\
+                   filter_empty_features: bool = True)\
                   -> biom.Table:
     _filter_table(table=table, min_frequency=min_frequency,
                   max_frequency=max_frequency, min_nonzero=min_features,
                   max_nonzero=max_features, metadata=metadata,
                   where=where, axis='sample', exclude_ids=exclude_ids,
-                  keep_zero_features=keep_zero_features)
+                  filter_opposite_axis=filter_empty_features)
 
     return table
 
@@ -83,12 +83,14 @@ def filter_features(table: biom.Table, min_frequency: int = 0,
                     max_frequency: int = None, min_samples: int = 0,
                     max_samples: int = None,
                     metadata: qiime2.Metadata = None, where: str = None,
-                    exclude_ids: bool = False)\
+                    exclude_ids: bool = False,
+                    filter_empty_samples: bool = True)\
                    -> biom.Table:
     _filter_table(table=table, min_frequency=min_frequency,
                   max_frequency=max_frequency, min_nonzero=min_samples,
                   max_nonzero=max_samples, metadata=metadata,
-                  where=where, axis='observation', exclude_ids=exclude_ids)
+                  where=where, axis='observation', exclude_ids=exclude_ids,
+                  filter_opposite_axis=filter_empty_samples)
 
     return table
 

--- a/q2_feature_table/_filter.py
+++ b/q2_feature_table/_filter.py
@@ -31,7 +31,8 @@ _other_axis_map = {'sample': 'observation', 'observation': 'sample'}
 
 
 def _filter_table(table, min_frequency, max_frequency, min_nonzero,
-                  max_nonzero, metadata, where, axis, exclude_ids=False):
+                  max_nonzero, metadata, where, axis, exclude_ids=False,
+                  keep_zero_features=False):
     if min_frequency == 0 and max_frequency is None and min_nonzero == 0 and\
        max_nonzero is None and metadata is None and where is None and\
        exclude_ids is False:
@@ -55,22 +56,25 @@ def _filter_table(table, min_frequency, max_frequency, min_nonzero,
 
     # filter on the opposite axis to remove any entities that now have a
     # frequency of zero
-    filter_fn2 = _get_biom_filter_function(
-        ids_to_keep=table.ids(axis=_other_axis_map[axis]), min_frequency=0,
-        max_frequency=None, min_nonzero=1, max_nonzero=None)
-    table.filter(filter_fn2, axis=_other_axis_map[axis], inplace=True)
+    if not keep_zero_features:
+        filter_fn2 = _get_biom_filter_function(
+            ids_to_keep=table.ids(axis=_other_axis_map[axis]), min_frequency=0,
+            max_frequency=None, min_nonzero=1, max_nonzero=None)
+        table.filter(filter_fn2, axis=_other_axis_map[axis], inplace=True)
 
 
 def filter_samples(table: biom.Table, min_frequency: int = 0,
                    max_frequency: int = None, min_features: int = 0,
                    max_features: int = None,
                    metadata: qiime2.Metadata = None, where: str = None,
-                   exclude_ids: bool = False)\
+                   exclude_ids: bool = False,
+                   keep_zero_features: bool = False)\
                   -> biom.Table:
     _filter_table(table=table, min_frequency=min_frequency,
                   max_frequency=max_frequency, min_nonzero=min_features,
                   max_nonzero=max_features, metadata=metadata,
-                  where=where, axis='sample', exclude_ids=exclude_ids)
+                  where=where, axis='sample', exclude_ids=exclude_ids,
+                  keep_zero_features=keep_zero_features)
 
     return table
 

--- a/q2_feature_table/plugin_setup.py
+++ b/q2_feature_table/plugin_setup.py
@@ -288,7 +288,8 @@ plugin.methods.register_function(
                 'max_features': Int,
                 'metadata': Metadata,
                 'where': Str,
-                'exclude_ids': Bool},
+                'exclude_ids': Bool,
+                'keep_zero_features':Bool},
     outputs=[('filtered_table', FeatureTable[T1])],
     input_descriptions={
         'table': 'The feature table from which samples should be filtered.'
@@ -315,7 +316,9 @@ plugin.methods.register_function(
                  'also in the feature table will be retained.',
         'exclude_ids': 'If true, the samples selected by `metadata` or '
                        '`where` parameters will be excluded from the filtered '
-                       'table instead of being retained.'
+                       'table instead of being retained.',
+        'keep_zero_features': 'If True, features which are not present in any '
+                              'retained samples are kept.'
     },
     output_descriptions={
         'filtered_table': 'The resulting feature table filtered by sample.'

--- a/q2_feature_table/plugin_setup.py
+++ b/q2_feature_table/plugin_setup.py
@@ -289,7 +289,7 @@ plugin.methods.register_function(
                 'metadata': Metadata,
                 'where': Str,
                 'exclude_ids': Bool,
-                'keep_zero_features':Bool},
+                'filter_empty_features': Bool},
     outputs=[('filtered_table', FeatureTable[T1])],
     input_descriptions={
         'table': 'The feature table from which samples should be filtered.'
@@ -317,8 +317,8 @@ plugin.methods.register_function(
         'exclude_ids': 'If true, the samples selected by `metadata` or '
                        '`where` parameters will be excluded from the filtered '
                        'table instead of being retained.',
-        'keep_zero_features': 'If True, features which are not present in any '
-                              'retained samples are kept.'
+        'filter_empty_features': 'If true, features which are not present in '
+                                 'any retained samples are dropped.',
     },
     output_descriptions={
         'filtered_table': 'The resulting feature table filtered by sample.'
@@ -369,7 +369,8 @@ plugin.methods.register_function(
                 'max_samples': Int,
                 'metadata': Metadata,
                 'where': Str,
-                'exclude_ids': Bool},
+                'exclude_ids': Bool,
+                'filter_empty_samples': Bool},
     outputs=[('filtered_table', FeatureTable[Frequency])],
     input_descriptions={
         'table': 'The feature table from which features should be filtered.'
@@ -396,7 +397,9 @@ plugin.methods.register_function(
                  'also in the feature table will be retained.',
         'exclude_ids': 'If true, the features selected by `metadata` or '
                        '`where` parameters will be excluded from the filtered '
-                       'table instead of being retained.'
+                       'table instead of being retained.',
+        'filter_empty_samples': 'If true, drop any samples where none of the '
+                                'retained features are present.',
     },
     output_descriptions={
         'filtered_table': 'The resulting feature table filtered by feature.'

--- a/q2_feature_table/tests/filter/test_filter_features.py
+++ b/q2_feature_table/tests/filter/test_filter_features.py
@@ -53,6 +53,27 @@ class FilterFeaturesTests(unittest.TestCase):
         expected = Table(np.array([]), [], [])
         self.assertEqual(actual, expected)
 
+    def test_filter_empty_samples(self):
+        # no filtering
+        table = Table(np.array([[0, 1, 1], [1, 1, 2]]),
+                      ['O1', 'O2'],
+                      ['S1', 'S2', 'S3'])
+        actual = filter_features(table, min_frequency=2,
+                                 filter_empty_samples=False)
+        expected = Table(np.array([[0, 1, 1], [1, 1, 2]]),
+                         ['O1', 'O2'],
+                         ['S1', 'S2', 'S3'])
+        self.assertEqual(actual, expected)
+
+        # filter all
+        table = Table(np.array([[0, 1, 1], [1, 1, 2]]),
+                      ['O1', 'O2'],
+                      ['S1', 'S2', 'S3'])
+        actual = filter_features(table, min_frequency=5,
+                                 filter_empty_samples=False)
+        expected = Table(np.empty((0, 3)), [], ['S1', 'S2', 'S3'])
+        self.assertEqual(actual, expected)
+
     def test_feature_metadata(self):
         # no filtering
         df = pd.DataFrame({'SequencedGenome': ['yes', 'yes']},

--- a/q2_feature_table/tests/filter/test_filter_samples.py
+++ b/q2_feature_table/tests/filter/test_filter_samples.py
@@ -111,6 +111,49 @@ class FilterSamplesTests(unittest.TestCase):
         expected = Table(np.array([]), [], [])
         self.assertEqual(actual, expected)
 
+    def test_filter_empty_features(self):
+        # no filtering
+        table = Table(np.array([[0, 1, 3], [1, 1, 2]]),
+                      ['O1', 'O2'],
+                      ['S1', 'S2', 'S3'])
+        actual = filter_samples(table, max_frequency=42,
+                                filter_empty_features=False)
+        expected = Table(np.array([[0, 1, 3], [1, 1, 2]]),
+                         ['O1', 'O2'],
+                         ['S1', 'S2', 'S3'])
+        self.assertEqual(actual, expected)
+
+        # filter one
+        table = Table(np.array([[0, 1, 3], [1, 1, 2]]),
+                      ['O1', 'O2'],
+                      ['S1', 'S2', 'S3'])
+        actual = filter_samples(table, max_frequency=4,
+                                filter_empty_features=False)
+        expected = Table(np.array([[0, 1], [1, 1]]),
+                         ['O1', 'O2'],
+                         ['S1', 'S2'])
+        self.assertEqual(actual, expected)
+
+        # filter two
+        table = Table(np.array([[0, 1, 3], [1, 1, 2]]),
+                      ['O1', 'O2'],
+                      ['S1', 'S2', 'S3'])
+        actual = filter_samples(table, max_frequency=1,
+                                filter_empty_features=False)
+        expected = Table(np.array([[0], [1]]),
+                         ['O1', 'O2'],
+                         ['S1'])
+        self.assertEqual(actual, expected)
+
+        # filter all
+        table = Table(np.array([[0, 1, 3], [1, 1, 2]]),
+                      ['O1', 'O2'],
+                      ['S1', 'S2', 'S3'])
+        actual = filter_samples(table, max_frequency=0,
+                                filter_empty_features=False)
+        expected = Table(np.array([[], []]), ['O1', 'O2'], [])
+        self.assertEqual(actual, expected)
+
     def test_min_features(self):
         # no filtering
         table = Table(np.array([[0, 1, 3], [1, 1, 2]]),


### PR DESCRIPTION

fixes #185 
Added keep-zero-features as an option, to filter-samples.  Default behavior is maintained, but if keep-zero-features is true then features with zero frequency in the filtered table are not dropped.