### PR TITLE
limiting the number of bins for seaborn.histplot

### DIFF
--- a/q2_feature_table/_summarize/_visualizer.py
+++ b/q2_feature_table/_summarize/_visualizer.py
@@ -106,7 +106,7 @@ def summarize(output_dir: str, table: biom.Table,
             bins = min(bins, MAX_BINS)
 
         feature_frequencies_ax = sns.histplot(feature_frequencies, kde=False,
-                                              bins=int(round(bins))
+                                              bins=int(round(bins)))
         feature_frequencies_ax.set_xlabel('Frequency per feature')
         feature_frequencies_ax.set_ylabel('Number of features')
         feature_frequencies_ax.set_xscale('log')


### PR DESCRIPTION
Adding a limit of [50 bins](https://github.com/mwaskom/seaborn/blob/09f5746ff214029ff068204a1d781c6ff7a3b25a/seaborn/distributions.py#L2625) for seaborn.histplot to reduce the amount of memory used. Using 50 bins as this is the upper limit in the previous method used seaborn.distplot.

Usage before this change:
```
$ /usr/bin/time -v conda run -n qiime2-2021.4 qiime feature-table summarize --i-table /qmounts/qiita_data/working_dir/8373aeae-05a8-47a0-98af-145753259715/test-species.qza --o-visualization /qmounts/qiita_data/working_dir/8373aeae-05a8-47a0-98af-145753259715/qiime2-2021.4.qzv
Saved Visualization to: /qmounts/qiita_data/working_dir/8373aeae-05a8-47a0-98af-145753259715/qiime2-2021.4.qzv
	Command being timed: "conda run -n qiime2-2021.4 qiime feature-table summarize --i-table /qmounts/qiita_data/working_dir/8373aeae-05a8-47a0-98af-145753259715/test-species.qza --o-visualization /qmounts/qiita_data/working_dir/8373aeae-05a8-47a0-98af-145753259715/qiime2-2021.4.qzv"
	User time (seconds): 2328.26
	System time (seconds): 44.34
	Percent of CPU this job got: 90%
	Elapsed (wall clock) time (h:mm:ss or m:ss): 43:30.43
	Average shared text size (kbytes): 0
	Average unshared data size (kbytes): 0
	Average stack size (kbytes): 0
	Average total size (kbytes): 0
	Maximum resident set size (kbytes): 15915448
	Average resident set size (kbytes): 0
	Major (requiring I/O) page faults: 3471
	Minor (reclaiming a frame) page faults: 41096065
	Voluntary context switches: 35592
	Involuntary context switches: 24135
	Swaps: 0
	File system inputs: 1213096
	File system outputs: 104008
	Socket messages sent: 0
	Socket messages received: 0
	Signals delivered: 0
	Page size (bytes): 4096
	Exit status: 0
```

After this change:
```
 $ /usr/bin/time -v conda run -n qiime2-2021.4 qiime feature-table summarize --i-table /qmounts/qiita_test_data/working_dir/8373aeae-05a8-47a0-98af-145753259715/test-species.qza --o-visualization qiime2-2021.4.qzv
										Saved Visualization to: qiime2-2021.4.qzv
	Command being timed: "conda run -n qiime2-2021.4 qiime feature-table summarize --i-table /qmounts/qiita_test_data/working_dir/8373aeae-05a8-47a0-98af-145753259715/test-species.qza --o-visualization qiime2-2021.4.qzv"
	User time (seconds): 17.45
	System time (seconds): 16.51
	Percent of CPU this job got: 188%
	Elapsed (wall clock) time (h:mm:ss or m:ss): 0:17.99
	Average shared text size (kbytes): 0
	Average unshared data size (kbytes): 0
	Average stack size (kbytes): 0
	Average total size (kbytes): 0
	Maximum resident set size (kbytes): 208248
	Average resident set size (kbytes): 0
	Major (requiring I/O) page faults: 0
	Minor (reclaiming a frame) page faults: 472589
	Voluntary context switches: 22901
	Involuntary context switches: 3316691
	Swaps: 0
	File system inputs: 16
	File system outputs: 12368
	Socket messages sent: 0
	Socket messages received: 0
	Signals delivered: 0
	Page size (bytes): 4096
	Exit status: 0
```