### PR TITLE
pin: matplotlib 3.6.0

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -21,6 +21,9 @@ requirements:
     - scikit-bio {{ scikit_bio }}
     - biom-format {{ biom_format }}
     - seaborn
+    # pinned here on 10.19.22 due to pkg int build failure on community
+    # due to matplotlib bug. will be resolved once 3.7.0 is released
+    - matplotlib =3.6.0
     - pandas {{ pandas }}
     - numpy
     # `ipywidgets` included to avoid ShimWarning from


### PR DESCRIPTION
This PR pins matplotlib to version 3.6.0 due to a [reported bug in seaborn](https://github.com/mwaskom/seaborn/issues/3072) (dep in q2-feature-table) caused from matplotlib version 3.6.1 that resulted in [build failures to our 2022.11 crons](https://github.com/qiime2/package-integration/actions/runs/3272779670) for the community distribution. As mentioned in the seaborn issue, the bug should be resolved with the new 3.7.0 build of matplotlib, and this pin will be removed at that time.