### PR TITLE
Rarefy with replacement bug

### DIFF
--- a/q2_feature_table/_normalize.py
+++ b/q2_feature_table/_normalize.py
@@ -11,6 +11,9 @@ import biom
 
 def rarefy(table: biom.Table, sampling_depth: int,
            with_replacement: bool = False) -> biom.Table:
+    if with_replacement:
+        table = table.filter(lambda v, i, m: v.sum() >= sampling_depth,
+                             inplace=False, axis='sample')
     table = table.subsample(sampling_depth, axis='sample', by_id=False,
                             with_replacement=with_replacement)
 

--- a/q2_feature_table/plugin_setup.py
+++ b/q2_feature_table/plugin_setup.py
@@ -53,8 +53,7 @@ plugin.methods.register_function(
         'sampling_depth': ('The total frequency that each sample should be '
                            'rarefied to. Samples where the sum of frequencies '
                            'is less than the sampling depth will be not be '
-                           'included in the resulting table unless '
-                           'subsampling is performed with replacement.'),
+                           'included in the resulting table.'),
         'with_replacement': ('Rarefy with replacement by sampling from the '
                              'multinomial distribution instead of rarefying '
                              'without replacement.')

--- a/q2_feature_table/tests/test_normalize.py
+++ b/q2_feature_table/tests/test_normalize.py
@@ -35,10 +35,14 @@ class RarefyTests(TestCase):
         self.assertEqual(rt.shape, (2, 3))
 
         # IMPORTANT: samples below subsample depth should be removed
-        for n_draws in range(11, 50, 5):
+        for n_draws in range(11, 21):
             rt = rarefy(t, n_draws, with_replacement=True)
             npt.assert_array_equal(rt.sum('sample'),
                                    np.array([n_draws] * 2))
+        for n_draws in range(21, 50):
+            rt = rarefy(t, n_draws, with_replacement=True)
+            npt.assert_array_equal(rt.sum('sample'),
+                                   np.array([n_draws] * 1))
 
     def test_rarefy_depth_error(self):
         t = Table(np.array([[0, 1, 3], [1, 1, 2]]),

--- a/q2_feature_table/tests/test_normalize.py
+++ b/q2_feature_table/tests/test_normalize.py
@@ -28,16 +28,17 @@ class RarefyTests(TestCase):
         npt.assert_array_equal(a.sum(axis='sample'), np.array([2., 2.]))
 
     def test_rarefy_replacement(self):
-        t = Table(np.array([[0, 1, 3], [1, 1, 2]]),
+        t = Table(np.array([[0, 10, 30], [10, 10, 20]]),
                   ['O1', 'O2'],
                   ['S1', 'S2', 'S3'])
         rt = rarefy(t, 3, with_replacement=True)
         self.assertEqual(rt.shape, (2, 3))
 
-        for n_draws in range(5, 100, 5):
+        # IMPORTANT: samples below subsample depth should be removed
+        for n_draws in range(11, 50, 5):
             rt = rarefy(t, n_draws, with_replacement=True)
             npt.assert_array_equal(rt.sum('sample'),
-                                   np.array([n_draws] * 3))
+                                   np.array([n_draws] * 2))
 
     def test_rarefy_depth_error(self):
         t = Table(np.array([[0, 1, 3], [1, 1, 2]]),


### PR DESCRIPTION
Rarefy `with_replacement=True` was incorrectly retaining samples with depth below the requested subsampling level. This behavior differed from `with_replacement=False`, where samples below depth are removed from the table. This Pull Request corrects the behavior of `with_replacement=True` by removing samples below the requested depth prior to subsampling. 
