### PR TITLE
ex: adds summarize/tabulate-seqs & some misc cleanup

### DIFF
--- a/q2_feature_table/_examples.py
+++ b/q2_feature_table/_examples.py
@@ -65,6 +65,8 @@ def feature_table_merge_two_tables(use):
         use.UsageOutputNames(merged_table='merged_table'),
     )
 
+    merged_table.assert_output_type('FeatureTable[Frequency]')
+
 
 def feature_table_merge_three_tables(use):
     feature_table1 = use.init_artifact('feature_table1', ft1_factory)
@@ -80,6 +82,8 @@ def feature_table_merge_three_tables(use):
         ),
         use.UsageOutputNames(merged_table='merged_table'),
     )
+
+    merged_table.assert_output_type('FeatureTable[Frequency]')
 
 
 def feature_table_merge_taxa(use):
@@ -98,6 +102,8 @@ def feature_table_merge_taxa(use):
         )
     )
 
+    merged_data.assert_output_type('FeatureData[Taxonomy]')
+
 
 def feature_table_merge_seqs(use):
     dada2_seqs = use.init_artifact_from_url('seqs1', rep_seqs_dada2_url)
@@ -113,6 +119,8 @@ def feature_table_merge_seqs(use):
         )
     )
 
+    merged_data.assert_output_type('FeatureData[Sequence]')
+
 
 def feature_table_filter_samples_min_features(use):
     feature_table = use.init_artifact_from_url(
@@ -126,6 +134,8 @@ def feature_table_filter_samples_min_features(use):
         use.UsageOutputNames(filtered_table='filtered_table')
     )
 
+    filtered_table.assert_output_type('FeatureTable[Frequency]')
+
 
 def feature_table_filter_samples_min_frequency(use):
     feature_table = use.init_artifact_from_url(
@@ -138,6 +148,8 @@ def feature_table_filter_samples_min_frequency(use):
                         min_frequency=1500),
         use.UsageOutputNames(filtered_table='filtered_table')
     )
+
+    filtered_table.assert_output_type('FeatureTable[Frequency]')
 
 
 def feature_table_filter_samples_to_subject1(use):
@@ -155,6 +167,8 @@ def feature_table_filter_samples_to_subject1(use):
         use.UsageOutputNames(filtered_table='filtered_table')
     )
 
+    filtered_table.assert_output_type('FeatureTable[Frequency]')
+
 
 def feature_table_filter_samples_to_skin(use):
     feature_table = use.init_artifact_from_url(
@@ -171,6 +185,8 @@ def feature_table_filter_samples_to_skin(use):
         use.UsageOutputNames(filtered_table='filtered_table')
     )
 
+    filtered_table.assert_output_type('FeatureTable[Frequency]')
+
 
 def feature_table_filter_samples_to_subject1_gut(use):
     feature_table = use.init_artifact_from_url(
@@ -186,6 +202,8 @@ def feature_table_filter_samples_to_subject1_gut(use):
                         where=r'[subject]="subject-1" AND [body-site]="gut"'),
         use.UsageOutputNames(filtered_table='filtered_table')
     )
+
+    filtered_table.assert_output_type('FeatureTable[Frequency]')
 
 
 def feature_table_filter_samples_to_gut_or_abx(use):
@@ -204,6 +222,8 @@ def feature_table_filter_samples_to_gut_or_abx(use):
         use.UsageOutputNames(filtered_table='filtered_table')
     )
 
+    filtered_table.assert_output_type('FeatureTable[Frequency]')
+
 
 def feature_table_filter_samples_to_subject1_not_gut(use):
     feature_table = use.init_artifact_from_url(
@@ -221,6 +241,8 @@ def feature_table_filter_samples_to_subject1_not_gut(use):
         use.UsageOutputNames(filtered_table='filtered_table')
     )
 
+    filtered_table.assert_output_type('FeatureTable[Frequency]')
+
 
 def feature_table_filter_features_min_samples(use):
     feature_table = use.init_artifact_from_url(
@@ -234,6 +256,8 @@ def feature_table_filter_features_min_samples(use):
                         min_samples=2),
         use.UsageOutputNames(filtered_table='filtered_table')
     )
+
+    filtered_table.assert_output_type('FeatureTable[Frequency]')
 
 
 def feature_table_filter_features_conditionally(use):
@@ -252,6 +276,8 @@ def feature_table_filter_features_conditionally(use):
                         prevalence=0.34),
         use.UsageOutputNames(filtered_table='filtered_table')
     )
+
+    filtered_table.assert_output_type('FeatureTable[Frequency]')
 
 
 def feature_table_group_samples(use):
@@ -276,3 +302,33 @@ def feature_table_group_samples(use):
                         axis='sample'),
         use.UsageOutputNames(grouped_table='body_site_table')
     )
+
+    filtered_table.assert_output_type('FeatureTable[Frequency]')
+
+
+def feature_table_summarize(use):
+    feature_table = use.init_artifact_from_url(
+        'feature_table', moving_pics_ft_url
+    )
+
+    viz, = use.action(
+        use.UsageAction('feature_table', 'summarize'),
+        use.UsageInputs(table=feature_table),
+        use.UsageOutputNames(visualization='table')
+    )
+
+    viz.assert_output_type('Visualization')
+
+
+def feature_table_tabulate_seqs(use):
+    rep_seqs = use.init_artifact_from_url(
+        'rep_seqs', rep_seqs_1_url
+    )
+
+    viz, = use.action(
+        use.UsageAction('feature_table', 'tabulate_seqs'),
+        use.UsageInputs(data=rep_seqs),
+        use.UsageOutputNames(visualization='rep-seqs')
+    )
+
+    viz.assert_output_type('Visualization')

--- a/q2_feature_table/plugin_setup.py
+++ b/q2_feature_table/plugin_setup.py
@@ -10,25 +10,13 @@ from qiime2.plugin import (Plugin, Int, Float, Range, Metadata, Str, Bool,
                            Choices, MetadataColumn, Categorical, List,
                            Citations, TypeMatch, TypeMap)
 
-import q2_feature_table
 from q2_types.feature_table import (
     FeatureTable, Frequency, RelativeFrequency, PresenceAbsence, Composition)
 from q2_types.feature_data import (
     FeatureData, Sequence, Taxonomy, AlignedSequence)
-from ._examples import (feature_table_merge_two_tables,
-                        feature_table_merge_three_tables,
-                        feature_table_merge_taxa,
-                        feature_table_merge_seqs,
-                        feature_table_filter_samples_to_subject1,
-                        feature_table_filter_samples_to_skin,
-                        feature_table_filter_samples_to_subject1_gut,
-                        feature_table_filter_samples_to_gut_or_abx,
-                        feature_table_filter_samples_to_subject1_not_gut,
-                        feature_table_filter_samples_min_features,
-                        feature_table_filter_samples_min_frequency,
-                        feature_table_filter_features_min_samples,
-                        feature_table_filter_features_conditionally,
-                        feature_table_group_samples)
+
+import q2_feature_table
+import q2_feature_table._examples as ex
 
 citations = Citations.load('citations.bib', package='q2_feature_table')
 plugin = Plugin(
@@ -183,7 +171,7 @@ plugin.methods.register_function(
     name="Group samples or features by a metadata column",
     description="Group samples or features in a feature table using metadata "
                 "to define the mapping of IDs to a group.",
-    examples={'group_samples': feature_table_group_samples}
+    examples={'group_samples': ex.feature_table_group_samples}
 )
 
 i_table, p_overlap_method, o_table = TypeMap({
@@ -216,9 +204,10 @@ plugin.methods.register_function(
     },
     name="Combine multiple tables",
     description="Combines feature tables using the `overlap_method` provided.",
-    examples={'feature_table_merge_two_tables': feature_table_merge_two_tables,
+    examples={'feature_table_merge_two_tables':
+              ex.feature_table_merge_two_tables,
               'feature_table_merge_three_tables':
-              feature_table_merge_three_tables},
+              ex.feature_table_merge_three_tables},
 )
 
 
@@ -242,7 +231,7 @@ plugin.methods.register_function(
                 "data is present for the same feature id in the inputs, "
                 "the data from the first will be propagated to the result.",
     examples={
-        'feature_table_merge_seqs': feature_table_merge_seqs
+        'feature_table_merge_seqs': ex.feature_table_merge_seqs
     }
 )
 
@@ -267,7 +256,7 @@ plugin.methods.register_function(
                 "data is present for the same feature id in the inputs, "
                 "the data from the first will be propagated to the result.",
     examples={
-        'feature_table_merge_taxa': feature_table_merge_taxa
+        'feature_table_merge_taxa': ex.feature_table_merge_taxa
     }
 )
 
@@ -359,14 +348,15 @@ plugin.methods.register_function(
                 "filtering will also be removed. See the filtering tutorial "
                 "on https://docs.qiime2.org for additional details.",
     examples={
-        'filter_to_subject1': feature_table_filter_samples_to_subject1,
-        'filter_to_skin': feature_table_filter_samples_to_skin,
-        'filter_to_subject1_gut': feature_table_filter_samples_to_subject1_gut,
-        'filter_to_gut_or_abx': feature_table_filter_samples_to_gut_or_abx,
+        'filter_to_subject1': ex.feature_table_filter_samples_to_subject1,
+        'filter_to_skin': ex.feature_table_filter_samples_to_skin,
+        'filter_to_subject1_gut':
+        ex.feature_table_filter_samples_to_subject1_gut,
+        'filter_to_gut_or_abx': ex.feature_table_filter_samples_to_gut_or_abx,
         'filter_to_subject1_not_gut':
-        feature_table_filter_samples_to_subject1_not_gut,
-        'filter_min_features': feature_table_filter_samples_min_features,
-        'filter_min_frequency': feature_table_filter_samples_min_frequency}
+        ex.feature_table_filter_samples_to_subject1_not_gut,
+        'filter_min_features': ex.feature_table_filter_samples_min_features,
+        'filter_min_frequency': ex.feature_table_filter_samples_min_frequency}
 )
 
 plugin.methods.register_function(
@@ -398,7 +388,7 @@ plugin.methods.register_function(
                  "removed."),
     examples={
         'feature_table_filter_features_conditionally':
-        feature_table_filter_features_conditionally
+        ex.feature_table_filter_features_conditionally
     }
 )
 
@@ -453,7 +443,8 @@ plugin.methods.register_function(
                 "filtering will also be removed. See the filtering tutorial "
                 "on https://docs.qiime2.org for additional details.",
     examples={
-     'filter_features_min_samples': feature_table_filter_features_min_samples
+     'filter_features_min_samples':
+     ex.feature_table_filter_features_min_samples
     }
 )
 
@@ -510,7 +501,10 @@ plugin.visualizers.register_function(
     input_descriptions={'table': 'The feature table to be summarized.'},
     parameter_descriptions={'sample_metadata': 'The sample metadata.'},
     name="Summarize table",
-    description="Generate visual and tabular summaries of a feature table."
+    description="Generate visual and tabular summaries of a feature table.",
+    examples={
+        'feature_table_summarize': ex.feature_table_summarize,
+    }
 )
 
 plugin.visualizers.register_function(
@@ -523,7 +517,10 @@ plugin.visualizers.register_function(
     description="Generate tabular view of feature identifier to sequence "
                 "mapping, including links to BLAST each sequence against "
                 "the NCBI nt database.",
-    citations=[citations['NCBI'], citations['NCBI-BLAST']]
+    citations=[citations['NCBI'], citations['NCBI-BLAST']],
+    examples={
+        'feature_table_tabulate_seqs': ex.feature_table_tabulate_seqs,
+    }
 )
 
 plugin.visualizers.register_function(


### PR DESCRIPTION
This PR adds usage examples for the following methods within q2-feature-table:
```
summarize
tabulate-seqs
```
In addition, I've done some minor clean-up to the existing examples to keep formatting consistent and reduce the number of separate imports happening within `plugin_setup.py`.