### PR TITLE
BUG: Removes 0 as header value when downloading CSVs

### DIFF
--- a/q2_feature_table/_summarize/_visualizer.py
+++ b/q2_feature_table/_summarize/_visualizer.py
@@ -134,9 +134,11 @@ def summarize(output_dir: str, table: biom.Table,
     sample_frequencies.sort_values(inplace=True, ascending=False)
     feature_frequencies.sort_values(inplace=True, ascending=False)
     sample_frequencies.to_csv(
-        os.path.join(output_dir, 'sample-frequency-detail.csv'))
+        os.path.join(output_dir, 'sample-frequency-detail.csv'),
+                     header = False)
     feature_frequencies.to_csv(
-        os.path.join(output_dir, 'feature-frequency-detail.csv'))
+        os.path.join(output_dir, 'feature-frequency-detail.csv'),
+        header = False)
 
     feature_frequencies = feature_frequencies.astype(int) \
         .apply('{:,}'.format).to_frame('Frequency')
@@ -272,7 +274,6 @@ def _frequencies(table, axis):
 
 def _frequency_summary(table, axis='sample'):
     frequencies = _frequencies(table, axis=axis)
-
     summary = pd.Series([frequencies.min(), frequencies.quantile(0.25),
                          frequencies.median(), frequencies.quantile(0.75),
                          frequencies.max(), frequencies.mean()],


### PR DESCRIPTION
fixes https://github.com/qiime2/q2-feature-table/issues/252

When downloading the Frequency per sample and the Frequency per feature CSVs from the feature-table summarize, a 0 was added as a placeholder column name. This was happening pandas .to_csv function, I set header to false and now pandas does not try to create a placeholder column name when creating those CSVs 

This PR does not have tests because it is an extensive process to test downloads from visualizations and this does not effect downstream workflows