### PR TITLE
DEP: removing matplotlib pin for unifrac update

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -21,9 +21,7 @@ requirements:
     - scikit-bio {{ scikit_bio }}
     - biom-format {{ biom_format }}
     - seaborn
-    # pinned here on 10.19.22 due to pkg int build failure on community
-    # due to matplotlib bug. will be resolved once 3.7.0 is released
-    - matplotlib =3.6.0
+    - matplotlib
     - pandas {{ pandas }}
     - numpy
     # `ipywidgets` included to avoid ShimWarning from


### PR DESCRIPTION
[related PR](https://github.com/qiime2/distributions/pull/4)