### PR TITLE
IMP: move sequences to furthest right column in tabulate-seqs

### DIFF
--- a/q2_feature_table/_summarize/tabulate_seqs_assets/index.html
+++ b/q2_feature_table/_summarize/tabulate_seqs_assets/index.html
@@ -89,8 +89,6 @@
         <thead>
           <tr>
             <th>Feature ID</th>
-            <th data-tsorter="numeric">Sequence</th>
-            <th data-tsorter="link">Sequence Length</th>
             {% if taxonomy is defined %}
               {% for name in taxonomy.keys() %}
             <th data-tsorter="text">Taxon: {{name}}</th>
@@ -101,19 +99,14 @@
             <th data-tsorter="text">{{ name }}</th>
               {% endfor %}
             {% endif %}
+            <th data-tsorter="link">Sequence Length</th>
+            <th data-tsorter="numeric">Sequence</th>
           </tr>
         </thead>
         <tbody>
         {% for sequence in display_sequences %}
           <tr>
             <td>{{ sequence }}</td>
-            {% if sequence in data %}
-            <td><samp><a target="_blank" href="{{ data[sequence].url }}" rel="noopener noreferrer">{{ data[sequence].seq }}</a></samp></td>
-            <td>{{ data[sequence].len }}</td>
-            {% else %}
-            <td>-</td>
-            <td>-</td>
-            {% endif %}
             {% if taxonomy is defined %}
               {% for member in taxonomy.values() %}
                 {% if sequence in member.index %}
@@ -133,6 +126,13 @@
             <td>-</td>
                 {% endfor %}
               {% endif %}
+            {% endif %}
+            {% if sequence in data %}
+            <td>{{ data[sequence].len }}</td>
+            <td><samp><a target="_blank" href="{{ data[sequence].url }}" rel="noopener noreferrer">{{ data[sequence].seq }}</a></samp></td>
+            {% else %}
+            <td>-</td>
+            <td>-</td>
             {% endif %}
           </tr>
         {% endfor %}


### PR DESCRIPTION
Since the sequences can be long and variable in length, if they show up first it's hard to actually review any provided metadata and taxonomy.

Here are some screenshots before:
![Screenshot 2025-04-25 at 10 45 29 AM](https://github.com/user-attachments/assets/01c9ee82-184b-448f-b576-a47372bc6cf8)

And _way_ over to the right:

![Screenshot 2025-04-25 at 10 45 47 AM](https://github.com/user-attachments/assets/8ce1b8b1-be2e-4611-8746-633ca5912ab2)

After:

![Screenshot 2025-04-25 at 10 56 34 AM](https://github.com/user-attachments/assets/219d870e-dfe1-4b73-8d54-1f255a4f207b)
