### PR TITLE
IMP: allow additional FeatureTable subtypes in heatmap

### DIFF
--- a/q2_feature_table/plugin_setup.py
+++ b/q2_feature_table/plugin_setup.py
@@ -594,7 +594,8 @@ plugin.visualizers.register_function(
 plugin.visualizers.register_function(
     function=q2_feature_table.heatmap,
     inputs={
-        'table': FeatureTable[Frequency]
+        'table': FeatureTable[Frequency | RelativeFrequency |
+                              PresenceAbsence | Composition]
     },
     parameters={
         'sample_metadata': MetadataColumn[Categorical],


### PR DESCRIPTION
closes #334 
-----------------------------------------
Adds `FeatureTable[RelativeFrequency | PresenceAbsence | Composition]` as allowed inputs.

I tested this with the DADA2 table from MP tutorial; heatmaps linked below:

- [Original table (for reference)](https://view.qiime2.org/visualization/?src=https://www.dropbox.com/scl/fi/vrunyrfrnygsh724n2163/viz-heatmap-table.qzv?rlkey=o8ldfx5v3e6cvjy0su4tf6uag)
- [RelativeFrequency](https://view.qiime2.org/visualization/?src=https://www.dropbox.com/scl/fi/lvgrdfx5sh6t7qiibygrp/rel-viz-heatmap-table.qzv?rlkey=5eqa2unjri6unf60trwae1h1r)
- [PresenceAbsence](https://view.qiime2.org/visualization/?src=https://www.dropbox.com/scl/fi/w9yy9rs79gh61m8bhd4nq/presabs-viz-heatmap-table.qzv?rlkey=i6evsnfvmixj9stfk8zzw35a6)
- [Composition](https://view.qiime2.org/visualization/?src=https://www.dropbox.com/scl/fi/kr4ra3jm4r056s5iwd9v8/comp-viz-heatmap-table.qzv?rlkey=50tc6z88dt96ad9prw13vbre9)