### PR TITLE
DOC: add documentation of filtering table w sequences 

### DIFF
--- a/q2_feature_table/_examples.py
+++ b/q2_feature_table/_examples.py
@@ -64,12 +64,14 @@ def ft3_factory():
               ['O1', 'O4'],
               ['S7', 'S8', 'S9']))
 
+
 def ft4_factory():
     return Artifact.import_data(
         'FeatureTable[Frequency]',
         Table(np.array([[0, 1], [1, 1], [88, 99]]),
               ['F1', 'F2', 'F3'],
               ['S1', 'S2']))
+
 
 def fd4_factory():
     seqs = pd.Series(['AACGT', 'GGAAT', 'GATAGTT', 'GGGGGGGG'],
@@ -295,6 +297,7 @@ def feature_table_filter_features_min_samples(use):
 
     filtered_table.assert_output_type('FeatureTable[Frequency]')
 
+
 def feature_table_filter_features_sequences(use):
     feature_table = use.init_artifact('feature_table', ft4_factory)
     sequences = use.init_artifact('sequences', fd4_factory)
@@ -305,7 +308,7 @@ def feature_table_filter_features_sequences(use):
                 "useful, for example, for removing sequences that are "
                 "identified as chimeric. To learn about "
                 "using Artifacts as Metadata, as is performed here, see "
-                "https://use.qiime2.org/en/latest/how-to-guides/artifacts-as-metadata.html")
+                "https://use.qiime2.org/en/latest/how-to-guides/artifacts-as-metadata.html") # noqa
 
     filtered_table, = use.action(
         use.UsageAction(plugin_id='feature_table',

--- a/q2_feature_table/_examples.py
+++ b/q2_feature_table/_examples.py
@@ -8,6 +8,7 @@
 
 import importlib
 
+import pandas as pd
 import numpy as np
 from biom import Table
 
@@ -62,6 +63,19 @@ def ft3_factory():
         Table(np.array([[0, 4, 9], [4, 4, 8]]),
               ['O1', 'O4'],
               ['S7', 'S8', 'S9']))
+
+def ft4_factory():
+    return Artifact.import_data(
+        'FeatureTable[Frequency]',
+        Table(np.array([[0, 1], [1, 1], [88, 99]]),
+              ['F1', 'F2', 'F3'],
+              ['S1', 'S2']))
+
+def fd4_factory():
+    seqs = pd.Series(['AACGT', 'GGAAT', 'GATAGTT', 'GGGGGGGG'],
+                     index=['F1', 'F2', 'F4', 'F5'])
+    return Artifact.import_data(
+        'FeatureData[Sequence]', seqs)
 
 
 def taxon_collection_factory():
@@ -276,6 +290,28 @@ def feature_table_filter_features_min_samples(use):
                         action_id='filter_features'),
         use.UsageInputs(table=feature_table,
                         min_samples=2),
+        use.UsageOutputNames(filtered_table='filtered_table')
+    )
+
+    filtered_table.assert_output_type('FeatureTable[Frequency]')
+
+def feature_table_filter_features_sequences(use):
+    feature_table = use.init_artifact('feature_table', ft4_factory)
+    sequences = use.init_artifact('sequences', fd4_factory)
+    metadata = use.view_as_metadata('metadata', sequences)
+
+    use.comment("Retain only features that are represented in the "
+                "collection of sequences provided as metadata. This is "
+                "useful, for example, for removing sequences that are "
+                "identified as chimeric. To learn about "
+                "using Artifacts as Metadata, as is performed here, see "
+                "https://use.qiime2.org/en/latest/how-to-guides/artifacts-as-metadata.html")
+
+    filtered_table, = use.action(
+        use.UsageAction(plugin_id='feature_table',
+                        action_id='filter_features'),
+        use.UsageInputs(table=feature_table,
+                        metadata=metadata),
         use.UsageOutputNames(filtered_table='filtered_table')
     )
 

--- a/q2_feature_table/plugin_setup.py
+++ b/q2_feature_table/plugin_setup.py
@@ -359,8 +359,7 @@ plugin.methods.register_function(
     name="Filter samples from table",
     description="Filter samples from table based on frequency and/or "
                 "metadata. Any features with a frequency of zero after sample "
-                "filtering will also be removed. See the filtering tutorial "
-                "on https://docs.qiime2.org for additional details.",
+                "filtering will also be removed.",
     examples={
         'filter_to_subject1': ex.feature_table_filter_samples_to_subject1,
         'filter_to_skin': ex.feature_table_filter_samples_to_skin,
@@ -461,11 +460,12 @@ plugin.methods.register_function(
     name="Filter features from table",
     description="Filter features from table based on frequency and/or "
                 "metadata. Any samples with a frequency of zero after feature "
-                "filtering will also be removed. See the filtering tutorial "
-                "on https://docs.qiime2.org for additional details.",
+                "filtering will also be removed.",
     examples={
      'filter_features_min_samples':
-     ex.feature_table_filter_features_min_samples
+     ex.feature_table_filter_features_min_samples,
+     'filter_features_sequences':
+     ex.feature_table_filter_features_sequences
     }
 )
 
@@ -507,11 +507,9 @@ plugin.methods.register_function(
     },
     name="Filter features from sequences",
     description="Filter features from sequences based on a feature table or "
-                "metadata. See the filtering tutorial on "
-                "https://docs.qiime2.org for additional details. This method "
-                "can filter based on ids in a table or a metadata file, but "
-                "not both (i.e., the table and metadata options are mutually "
-                "exclusive)."
+                "metadata. This method can filter based on ids in a table or "
+                "a metadata file, but not both (i.e., the table and metadata "
+                "options are mutually exclusive)."
 )
 
 plugin.visualizers.register_function(


### PR DESCRIPTION
closes [#595](https://github.com/qiime2/docs/issues/595)

Confirmed that this works as expected locally:

Input table:
<img width="895" alt="Screenshot 2025-06-25 at 12 54 30 PM" src="https://github.com/user-attachments/assets/0a27591f-74b8-4fdc-8276-f2441e73ae3f" />

Input sequences (notice no F3):
<img width="585" alt="Screenshot 2025-06-25 at 12 54 48 PM" src="https://github.com/user-attachments/assets/e3a9e89f-f48d-49af-8b6b-417a9f6ed017" />

Output table:
<img width="735" alt="Screenshot 2025-06-25 at 12 54 37 PM" src="https://github.com/user-attachments/assets/51734105-32d8-44dd-abbf-0b0e865c6bb2" />
