### PR TITLE
Fixing incorrect sequence counts in tabulate-squences

### DIFF
--- a/q2_feature_table/_split.py
+++ b/q2_feature_table/_split.py
@@ -16,9 +16,10 @@ def split(table: biom.Table,
     metadata = metadata.filter_ids(table.ids(axis='sample'))
     metadata_df = metadata.drop_missing_values().to_dataframe()
     lookup = metadata_df[metadata.name].to_dict()
+
+    unique_groups = sorted(set(lookup.values()))
     try:
-        qiime2.sdk.util.validate_result_collection_keys(*(
-            sorted(set(lookup.values()))))
+        qiime2.sdk.util.validate_result_collection_keys(*unique_groups)
     except KeyError as e:
         raise KeyError(
             "One or more invalid metadata column values identified during "
@@ -27,9 +28,12 @@ def split(table: biom.Table,
             f"table. The original error message is as follows: {str(e)}")
 
     result = {}
-    for group, tab in table.partition(lookup, axis='sample',
-                                      remove_empty=filter_empty_features,
-                                      ignore_none=True):
-
+    for group, tab in table.partition(
+            lookup,
+            axis='sample',
+            remove_empty=filter_empty_features,
+            ignore_none=True
+    ):
         result[group] = tab
+
     return result

--- a/q2_feature_table/_split.py
+++ b/q2_feature_table/_split.py
@@ -16,13 +16,9 @@ def split(table: biom.Table,
     metadata = metadata.filter_ids(table.ids(axis='sample'))
     metadata_df = metadata.drop_missing_values().to_dataframe()
     lookup = metadata_df[metadata.name].to_dict()
-
-    def partition_f(i, m):
-        return lookup.get(i)
-
-    unique_grps = sorted(set(lookup.values()))
     try:
-        qiime2.sdk.util.validate_result_collection_keys(*unique_grps)
+        qiime2.sdk.util.validate_result_collection_keys(*(
+            sorted(set(lookup.values()))))
     except KeyError as e:
         raise KeyError(
             "One or more invalid metadata column values identified during "
@@ -31,11 +27,9 @@ def split(table: biom.Table,
             f"table. The original error message is as follows: {str(e)}")
 
     result = {}
-    for group, tab in table.partition(partition_f):
-        if group is None:
-            continue
+    for group, tab in table.partition(lookup, axis='sample',
+                                      remove_empty=filter_empty_features,
+                                      ignore_none=True):
 
-        if filter_empty_features:
-            tab.remove_empty(axis='observation', inplace=True)
         result[group] = tab
     return result

--- a/q2_feature_table/_summarize/_visualizer.py
+++ b/q2_feature_table/_summarize/_visualizer.py
@@ -35,54 +35,46 @@ def tabulate_seqs(output_dir: str, data: DNAIterator,
                   metadata: qiime2.Metadata = None,
                   merge_method: str = 'strict') -> None:
 
-    display_sequences = {}
+    display_sequences = set()
     sequences = {}
-    seq_lengths = []
     with open(os.path.join(output_dir, 'sequences.fasta'), 'w') as fh:
         for sequence in data:
             skbio.io.write(sequence, format='fasta', into=fh)
             str_seq = str(sequence)
             seq_len = len(str_seq)
-            display_sequences[sequence.metadata['id']] = seq_len
+            display_sequences.add(sequence.metadata['id'])
             sequences[sequence.metadata['id']]\
                 = {'len': seq_len,
                    'url': _blast_url_template % str_seq,
                    'seq': str_seq}
-            seq_lengths.append(seq_len)
 
     if metadata is not None:
         metadata_df = metadata.to_dataframe()
         if merge_method == 'union':
-            for id in metadata_df.index:
-                if id not in display_sequences:
-                    display_sequences[id] = None
+            display_sequences = display_sequences.union(metadata_df.index)
         elif merge_method == 'intersect':
-            display_sequences = {
-                k: v for k, v in display_sequences.items()
-                if k in metadata_df.index
-            }
+            display_sequences = display_sequences.intersection(
+                metadata_df.index
+            )
         elif merge_method == 'strict':
-            if set(metadata_df.index) != set(display_sequences):
+            if set(metadata_df.index) != display_sequences:
                 raise ValueError('Merge method is strict and IDs do not match')
     if taxonomy is not None:
         for member in taxonomy.values():
             if merge_method == 'union':
-                for id in member.index:
-                    if id not in display_sequences:
-                        display_sequences[id] = None
+                display_sequences = display_sequences.union(member.index)
             elif merge_method == 'intersect':
-                display_sequences = {
-                    k: v for k, v in display_sequences.items()
-                    if k in member.index
-                }
+                display_sequences = display_sequences.intersection(
+                    member.index
+                )
             elif merge_method == 'strict':
-                if set(member.index) != set(display_sequences):
+                if set(member.index) != display_sequences:
                     raise ValueError(
                                 'Merge method is strict and IDs do not match'
                     )
 
     seq_lengths = [
-        length for length in display_sequences.values() if length is not None
+        v['len'] for k, v in sequences.items() if k in display_sequences
     ]
 
     seq_len_stats = _compute_descriptive_stats(seq_lengths)

--- a/q2_feature_table/_summarize/_visualizer.py
+++ b/q2_feature_table/_summarize/_visualizer.py
@@ -82,7 +82,10 @@ def tabulate_seqs(output_dir: str, data: DNAIterator,
                     )
 
     if merge_method == 'union':
-        seq_lengths = list(display_sequences.values())
+        seq_lengths = [
+            length for length in display_sequences.values()
+            if length is not None
+        ]
 
     seq_len_stats = _compute_descriptive_stats(seq_lengths)
     _write_tsvs_of_descriptive_stats(seq_len_stats, output_dir)

--- a/q2_feature_table/_summarize/_visualizer.py
+++ b/q2_feature_table/_summarize/_visualizer.py
@@ -81,11 +81,9 @@ def tabulate_seqs(output_dir: str, data: DNAIterator,
                                 'Merge method is strict and IDs do not match'
                     )
 
-    if merge_method == 'union':
-        seq_lengths = [
-            length for length in display_sequences.values()
-            if length is not None
-        ]
+    seq_lengths = [
+        length for length in display_sequences.values() if length is not None
+    ]
 
     seq_len_stats = _compute_descriptive_stats(seq_lengths)
     _write_tsvs_of_descriptive_stats(seq_len_stats, output_dir)

--- a/q2_feature_table/_summarize/_visualizer.py
+++ b/q2_feature_table/_summarize/_visualizer.py
@@ -35,7 +35,7 @@ def tabulate_seqs(output_dir: str, data: DNAIterator,
                   metadata: qiime2.Metadata = None,
                   merge_method: str = 'strict') -> None:
 
-    display_sequences = set()
+    display_sequences = {}
     sequences = {}
     seq_lengths = []
     with open(os.path.join(output_dir, 'sequences.fasta'), 'w') as fh:
@@ -43,7 +43,7 @@ def tabulate_seqs(output_dir: str, data: DNAIterator,
             skbio.io.write(sequence, format='fasta', into=fh)
             str_seq = str(sequence)
             seq_len = len(str_seq)
-            display_sequences.add(sequence.metadata['id'])
+            display_sequences[sequence.metadata['id']] = seq_len
             sequences[sequence.metadata['id']]\
                 = {'len': seq_len,
                    'url': _blast_url_template % str_seq,
@@ -53,24 +53,36 @@ def tabulate_seqs(output_dir: str, data: DNAIterator,
     if metadata is not None:
         metadata_df = metadata.to_dataframe()
         if merge_method == 'union':
-            display_sequences = display_sequences.union(metadata_df.index)
+            for id in metadata_df.index:
+                if id not in display_sequences:
+                    display_sequences[id] = None
         elif merge_method == 'intersect':
-            display_sequences = display_sequences.intersection(
-                metadata_df.index)
+            display_sequences = {
+                k: v for k, v in display_sequences.items()
+                if k in metadata_df.index
+            }
         elif merge_method == 'strict':
-            if set(metadata_df.index) != display_sequences:
+            if set(metadata_df.index) != set(display_sequences):
                 raise ValueError('Merge method is strict and IDs do not match')
     if taxonomy is not None:
         for member in taxonomy.values():
             if merge_method == 'union':
-                display_sequences = display_sequences.union(member.index)
+                for id in member.index:
+                    if id not in display_sequences:
+                        display_sequences[id] = None
             elif merge_method == 'intersect':
-                display_sequences = display_sequences.intersection(
-                    member.index)
+                display_sequences = {
+                    k: v for k, v in display_sequences.items()
+                    if k in member.index
+                }
             elif merge_method == 'strict':
-                if set(member.index) != display_sequences:
+                if set(member.index) != set(display_sequences):
                     raise ValueError(
-                                'Merge method is strict and IDs do not match')
+                                'Merge method is strict and IDs do not match'
+                    )
+
+    if merge_method == 'union':
+        seq_lengths = list(display_sequences.values())
 
     seq_len_stats = _compute_descriptive_stats(seq_lengths)
     _write_tsvs_of_descriptive_stats(seq_len_stats, output_dir)

--- a/q2_feature_table/tests/test_summarize.py
+++ b/q2_feature_table/tests/test_summarize.py
@@ -92,6 +92,10 @@ class TabulateSeqsTests(TestCase):
             _compute_descriptive_stats(seq_lengths)
 
     def test_seq_count_union(self):
+        """
+        This tests that the sequence count is equal to the sequence count in
+        the DNA iterator passed into to `tabulate_seqs`.
+        """
         seqs = DNAIterator(skbio.DNA(a, metadata=b)for a, b in (
             ('ACGT', {'id': 'seq01'}),
             ('AAAA', {'id': 'seq02'}),
@@ -133,10 +137,16 @@ class TabulateSeqsTests(TestCase):
 
             with open(Path(output_dir) / 'descriptive_stats.tsv', 'r') as f:
                 lines = f.readlines()
-                self.assertTrue('count\t8' in line for line in lines)
+                for line in lines:
+                    print(line)
+                self.assertTrue('count\t5\n' in lines)
 
     def test_seq_count_intersection(self):
-        seqs = DNAIterator(skbio.DNA(a, metadata=b) for a, b in (
+        """
+        This tests that the sequence count reflects the intersection of the
+        data, metadata, and taxonomy.
+        """
+        seqs = DNAIterator(skbio.DNA(seq, metadata=md) for seq, md in (
             ('AAAA', {'id': 'seq02'}),
             ('GGGG', {'id': 'seq03'}),
             ('GGGG', {'id': 'seq04'}),
@@ -176,7 +186,7 @@ class TabulateSeqsTests(TestCase):
 
             with open(Path(output_dir) / 'descriptive_stats.tsv', 'r') as f:
                 lines = f.readlines()
-                self.assertTrue('count\t3' in line for line in lines)
+                self.assertTrue('count\t3\n' in lines)
 
     def test_descriptive_stats_integration(self):
         seqs = DNAIterator(skbio.DNA(a, metadata=b)for a, b in (

--- a/q2_feature_table/tests/test_summarize.py
+++ b/q2_feature_table/tests/test_summarize.py
@@ -21,6 +21,7 @@ from selenium import webdriver
 from selenium.webdriver.chrome.options import Options as ChromeOptions
 from selenium.webdriver.firefox.options import Options as FirefoxOptions
 from selenium.webdriver.common.by import By
+from pathlib import Path
 
 import qiime2
 from q2_types.feature_data import DNAIterator
@@ -89,6 +90,93 @@ class TabulateSeqsTests(TestCase):
         seq_lengths = []
         with self.assertRaisesRegex(ValueError, 'No values provided.'):
             _compute_descriptive_stats(seq_lengths)
+
+    def test_seq_count_union(self):
+        seqs = DNAIterator(skbio.DNA(a, metadata=b)for a, b in (
+            ('ACGT', {'id': 'seq01'}),
+            ('AAAA', {'id': 'seq02'}),
+            ('GGGG', {'id': 'seq03'}),
+            ('GGGG', {'id': 'seq04'}),
+            ('TTTT', {'id': 'seq05'})
+        ))
+
+        metadata = pd.DataFrame(index=['seq01', 'seq02',
+                                       'seq03', 'seq04',
+                                       'seq05', 'seq06',
+                                       'seq07', 'seq08'],
+                                columns=['att1', 'att2'],
+                                data=[['00', '01'], ['10', '11'],
+                                      ['03', '04'], ['12', '13'],
+                                      ['05', '06'], ['14', '15'],
+                                      ['07', '08'], ['16', '17']])
+        metadata.index.name = 'feature id'
+
+        metadata = qiime2.Metadata(metadata)
+
+        taxonomy = pd.DataFrame([('a;b;c;d', '1.0'), ('a;b;c;f', '0.7'),
+                                 ('a;b;h;d', '0.3'), ('a;b;d;f', '0.7'),
+                                 ('a;b;e;d', '0.4'), ('a;b;c;f', '0.6'),
+                                 ('a;b;t;d', '1.0'), ('a;b;d;f', '0.5')],
+                                index=['seq01', 'seq02', 'seq03', 'seq04',
+                                       'seq05', 'seq06', 'seq07', 'seq08'],
+                                columns=['Taxon', 'Confidence'])
+        taxonomy = {"Taxon Name": taxonomy}
+
+        with tempfile.TemporaryDirectory() as output_dir:
+            tabulate_seqs(
+                output_dir,
+                seqs,
+                taxonomy=taxonomy,
+                metadata=metadata,
+                merge_method='union'
+            )
+
+            with open(Path(output_dir) / 'descriptive_stats.tsv', 'r') as f:
+                lines = f.readlines()
+                self.assertTrue('count\t8' in line for line in lines)
+
+    def test_seq_count_intersection(self):
+        seqs = DNAIterator(skbio.DNA(a, metadata=b) for a, b in (
+            ('AAAA', {'id': 'seq02'}),
+            ('GGGG', {'id': 'seq03'}),
+            ('GGGG', {'id': 'seq04'}),
+            ('TTTT', {'id': 'seq11'}),
+        ))
+
+        metadata = pd.DataFrame(index=['seq01', 'seq02',
+                                       'seq03', 'seq04',
+                                       'seq05', 'seq06',
+                                       'seq07', 'seq08'],
+                                columns=['att1', 'att2'],
+                                data=[['00', '01'], ['10', '11'],
+                                      ['03', '04'], ['12', '13'],
+                                      ['05', '06'], ['14', '15'],
+                                      ['07', '08'], ['16', '17']])
+        metadata.index.name = 'feature id'
+
+        metadata = qiime2.Metadata(metadata)
+
+        taxonomy = pd.DataFrame([('a;b;c;d', '1.0'), ('a;b;c;f', '0.7'),
+                                 ('a;b;h;d', '0.3'), ('a;b;d;f', '0.7'),
+                                 ('a;b;e;d', '0.4'), ('a;b;c;f', '0.6'),
+                                 ('a;b;t;d', '1.0'), ('a;b;d;f', '0.5')],
+                                index=['seq01', 'seq02', 'seq03', 'seq04',
+                                       'seq05', 'seq06', 'seq07', 'seq08'],
+                                columns=['Taxon', 'Confidence'])
+        taxonomy = {"Taxon Name": taxonomy}
+
+        with tempfile.TemporaryDirectory() as output_dir:
+            tabulate_seqs(
+                output_dir,
+                seqs,
+                taxonomy=taxonomy,
+                metadata=metadata,
+                merge_method='intersect'
+            )
+
+            with open(Path(output_dir) / 'descriptive_stats.tsv', 'r') as f:
+                lines = f.readlines()
+                self.assertTrue('count\t3' in line for line in lines)
 
     def test_descriptive_stats_integration(self):
         seqs = DNAIterator(skbio.DNA(a, metadata=b)for a, b in (


### PR DESCRIPTION
The sequence count and sequence length stats will now reflect the data passed in for `merge-method=union`, and reflects the number of sequences kept after intersecting for `merge-method=intersect` in `tabulate-seqs`