### PR TITLE
Added warnings for merging tables with differing levels of taxonomic depth

### DIFF
--- a/q2_feature_table/_merge.py
+++ b/q2_feature_table/_merge.py
@@ -71,11 +71,29 @@ def merge_seqs(data: pd.Series) -> pd.Series:
     return _merge_feature_data(data)
 
 
-def merge_taxa(data: pd.DataFrame) -> pd.DataFrame:
-    data = _merge_feature_data(data)
+def merge_taxa(data: list[pd.DataFrame]) -> pd.DataFrame:
+
+    frame_one = data[0]
+    frame_two = data[1]
+
+    count = frame_one["Taxon"].str.count(';')
+    count_two = frame_two["Taxon"].str.count(';')
+
+    if not count.equals(count_two):
+        raise ValueError(
+            "You are trying to merge tables with different levels of taxonomic"
+            " depth, this may cause failures later."
+        )
+    if 0 in count.values:
+        raise ValueError(
+            "You are trying to merge tables with one level of taxonomic"
+            " depth, this may cause failures later."
+        )
+
     # merge orders columns alphabetically; Taxon must be first header column
     # as defined here: https://github.com/qiime2/q2-types/blob/
     # 067d83e2aefe98674433e95162336fb5b9d96474/q2_types/feature_data/
     # _format.py#L97
+    data = _merge_feature_data(data)
     data = data[data.columns.drop('Taxon').insert(0, 'Taxon')]
     return data

--- a/q2_feature_table/_merge.py
+++ b/q2_feature_table/_merge.py
@@ -79,12 +79,17 @@ def merge_taxa(data: list[pd.DataFrame]) -> pd.DataFrame:
     count = frame_one["Taxon"].str.count(';')
     count_two = frame_two["Taxon"].str.count(';')
 
-    if not count.equals(count_two):
-        raise ValueError(
-            "You are trying to merge tables with different levels of taxonomic"
-            " depth, this may cause failures later."
-        )
-    if 0 in count.values:
+    for index, value in count.items():
+        try:
+            if value != count_two[index]:
+                raise ValueError(
+                    "You are trying to merge tables with different levels of "
+                    "taxonomic depth, this may cause failures later."
+                )
+        except KeyError:
+            continue
+
+    if (count == 0).any():
         raise ValueError(
             "You are trying to merge tables with one level of taxonomic"
             " depth, this may cause failures later."

--- a/q2_feature_table/tests/test_merge.py
+++ b/q2_feature_table/tests/test_merge.py
@@ -349,6 +349,39 @@ class MergeFeatureTaxonomyTests(unittest.TestCase):
             index=['f1', 'f2', 'f3'], columns=['Taxon', 'Confidence'])
         pdt.assert_frame_equal(obs, exp)
 
+    def test_merge_taxa_different_levels(self):
+        data_one = pd.DataFrame(
+            [('a;b;c;d', '1.0'), ('a;b;c;f', '0.7')],
+            index=['f1', 'f2'],
+            columns=['Taxon', 'Confidence']
+        )
+        data_two = pd.DataFrame(
+            [('a;b;c;d;', '1.0'), ('a;b;c;f', '0.7')],
+            index=['f1', 'f2'],
+            columns=['Taxon', 'Confidence']
+        )
+
+        with (self.assertRaises(ValueError)):
+            merge_taxa([data_one, data_two]),
+            "You are trying to merge tables with different levels of taxonomic"
+            " depth, this may cause failures later."
+
+        data_one = pd.DataFrame(
+            [('a', '1.0'), ('a', '0.7')],
+            index=['f1', 'f2'],
+            columns=['Taxon', 'Confidence']
+        )
+        data_two = pd.DataFrame(
+            [('a', '1.0'), ('a', '0.7')],
+            index=['f1', 'f2'],
+            columns=['Taxon', 'Confidence']
+        )
+
+        with self.assertRaises(ValueError):
+            merge_taxa([data_one, data_two]),
+            "You are trying to merge tables with one level of taxonomic"
+            " depth, this may cause failures later."
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Adds warnings for merging tables with differing levels of taxonomic depth, and adds a warning when merging tables with one one level of taxonomic depth in `merge_taxa`. 

Addresses #341 
