### PR TITLE
ENH: add FeatureTable[RelativeFrequency] to the filter-features action

### DIFF
--- a/q2_feature_table/_filter.py
+++ b/q2_feature_table/_filter.py
@@ -98,14 +98,14 @@ def filter_samples(table: biom.Table, min_frequency: int = 0,
 
 
 def filter_features(table: biom.Table, min_frequency: int = 0,
-                    max_frequency: int | str = "inf", min_samples: int = 0,
+                    max_frequency: int | str = 'None', min_samples: int = 0,
                     max_samples: int = None,
                     metadata: qiime2.Metadata = None, where: str = None,
                     exclude_ids: bool = False,
                     filter_empty_samples: bool = True,
                     allow_empty_table: bool = False)\
                    -> biom.Table:
-    if max_frequency == 'inf':
+    if max_frequency == 'None':
         max_frequency = None
 
     is_relative_frequency = check_relative_frequency(table)

--- a/q2_feature_table/_filter.py
+++ b/q2_feature_table/_filter.py
@@ -91,13 +91,16 @@ def filter_samples(table: biom.Table, min_frequency: int = 0,
 
 
 def filter_features(table: biom.Table, min_frequency: int = 0,
-                    max_frequency: int = None, min_samples: int = 0,
+                    max_frequency: int | str = "inf", min_samples: int = 0,
                     max_samples: int = None,
                     metadata: qiime2.Metadata = None, where: str = None,
                     exclude_ids: bool = False,
                     filter_empty_samples: bool = True,
                     allow_empty_table: bool = False)\
                    -> biom.Table:
+    if max_frequency == 'inf':
+        max_frequency = None
+
     _filter_table(table=table, min_frequency=min_frequency,
                   max_frequency=max_frequency, min_nonzero=min_samples,
                   max_nonzero=max_samples, metadata=metadata,

--- a/q2_feature_table/_filter.py
+++ b/q2_feature_table/_filter.py
@@ -11,6 +11,8 @@ import qiime2
 import numpy as np
 import pandas as pd
 
+from ._transform import relative_frequency
+
 
 def _validate_nonempty_table(table):
     if table.is_empty():
@@ -18,6 +20,11 @@ def _validate_nonempty_table(table):
                          "you filter all samples or features out of the "
                          "table. Please check your filtering parameters and "
                          "try again.")
+
+
+def check_relative_frequency(table: biom.Table) -> bool:
+    sample_sums = table.sum(axis='sample')
+    return (np.isclose(sample_sums, 1) | np.isclose(sample_sums, 0)).all()
 
 
 def _get_biom_filter_function(ids_to_keep, min_frequency, max_frequency,
@@ -101,12 +108,17 @@ def filter_features(table: biom.Table, min_frequency: int = 0,
     if max_frequency == 'inf':
         max_frequency = None
 
+    is_relative_frequency = check_relative_frequency(table)
+
     _filter_table(table=table, min_frequency=min_frequency,
                   max_frequency=max_frequency, min_nonzero=min_samples,
                   max_nonzero=max_samples, metadata=metadata,
                   where=where, axis='observation', exclude_ids=exclude_ids,
                   filter_opposite_axis=filter_empty_samples,
                   allow_empty_table=allow_empty_table)
+
+    if is_relative_frequency and not table.is_empty():
+        relative_frequency(table)
 
     return table
 

--- a/q2_feature_table/plugin_setup.py
+++ b/q2_feature_table/plugin_setup.py
@@ -423,10 +423,10 @@ plugin.methods.register_function(
      Int % Range(0, None)): FeatureTable[Frequency],
     (FeatureTable[Frequency],
      Int % Range(0, None),
-     Str % Choices(['inf'])): FeatureTable[Frequency],
+     Str % Choices(['None'])): FeatureTable[Frequency],
     (FeatureTable[RelativeFrequency],
      Int % Range(0, 0, inclusive_start=True, inclusive_end=True),
-     Str % Choices(['inf'])): FeatureTable[RelativeFrequency],
+     Str % Choices(['None'])): FeatureTable[RelativeFrequency],
 })
 
 plugin.methods.register_function(

--- a/q2_feature_table/plugin_setup.py
+++ b/q2_feature_table/plugin_setup.py
@@ -412,12 +412,28 @@ plugin.methods.register_function(
     }
 )
 
+(
+    i_filter_features_table,
+    p_filter_features_min_frequency,
+    p_filter_features_max_frequency,
+    o_filter_features_table,
+) = TypeMap({
+    (FeatureTable[Frequency],
+     Int % Range(0, None),
+     Int % Range(0, None)): FeatureTable[Frequency],
+    (FeatureTable[Frequency],
+     Int % Range(0, None),
+     Str % Choices(['inf'])): FeatureTable[Frequency],
+    (FeatureTable[RelativeFrequency],
+     Int % Range(0, 0, inclusive_start=True, inclusive_end=True),
+     Str % Choices(['inf'])): FeatureTable[RelativeFrequency],
+})
 
 plugin.methods.register_function(
     function=q2_feature_table.filter_features,
-    inputs={'table': FeatureTable[Frequency]},
-    parameters={'min_frequency': Int,
-                'max_frequency': Int,
+    inputs={'table': i_filter_features_table},
+    parameters={'min_frequency': p_filter_features_min_frequency,
+                'max_frequency': p_filter_features_max_frequency,
                 'min_samples': Int,
                 'max_samples': Int,
                 'metadata': Metadata,
@@ -425,17 +441,20 @@ plugin.methods.register_function(
                 'exclude_ids': Bool,
                 'filter_empty_samples': Bool,
                 'allow_empty_table': Bool},
-    outputs=[('filtered_table', FeatureTable[Frequency])],
+    outputs=[('filtered_table', o_filter_features_table)],
     input_descriptions={
         'table': 'The feature table from which features should be filtered.'
     },
     parameter_descriptions={
         'min_frequency': ('The minimum total frequency that a feature must '
-                          'have to be retained.'),
+                          'have to be retained. This parameter can only be '
+                          'used with FeatureTable[Frequency] inputs.'),
         'max_frequency': ('The maximum total frequency that a feature can '
                           'have to be retained. If no value is provided '
                           'this will default to infinity (i.e., no maximum '
-                          'frequency filter will be applied).'),
+                          'frequency filter will be applied). This parameter '
+                          'can only be used with FeatureTable[Frequency] '
+                          'inputs.'),
         'min_samples': ('The minimum number of samples that a feature must '
                         'be observed in to be retained.'),
         'max_samples': ('The maximum number of samples that a feature can '

--- a/q2_feature_table/tests/filter/test_filter_features.py
+++ b/q2_feature_table/tests/filter/test_filter_features.py
@@ -14,6 +14,7 @@ import pandas as pd
 from biom.table import Table
 
 from q2_feature_table import filter_features
+from q2_feature_table._filter import check_relative_frequency
 
 
 class FilterFeaturesTests(unittest.TestCase):
@@ -216,6 +217,47 @@ class FilterFeaturesTests(unittest.TestCase):
                          ['O2'],
                          ['S1', 'S2', 'S3'])
         self.assertEqual(actual, expected)
+
+    def test_check_relative_frequency_true(self):
+        table = Table(np.array([[0.2, 0.5, 0.3],
+                                [0.8, 0.5, 0.7],
+                                [0.0, 0.0, 0.0]]),
+                      ['O1', 'O2', 'O3'],
+                      ['S1', 'S2', 'S3'])
+
+        self.assertTrue(check_relative_frequency(table))
+
+    def test_check_relative_frequency_false(self):
+        table = Table(np.array([[0.2, 0.5, 0.3],
+                                [0.3, 0.1, 0.6]]),
+                      ['O1', 'O2'],
+                      ['S1', 'S2', 'S3'])
+
+        self.assertFalse(check_relative_frequency(table))
+
+    def test_relative_frequency(self):
+        table = Table(np.array([[0.2, 0.5, 0.3, 0.0],
+                                [0.3, 0.1, 0.6, 0.0],
+                                [0.5, 0.4, 0.1, 0.0]]),
+                      ['O1', 'O2', 'O3'],
+                      ['S1', 'S2', 'S3', 'S4'])
+        metadata = qiime2.Metadata(
+            pd.DataFrame({'keep': ['yes', 'no', 'yes']},
+                         index=pd.Index(['O1', 'O2', 'O3'], name='id')))
+        actual = filter_features(table, metadata=metadata,
+                                 where="keep='yes'",
+                                 filter_empty_samples=False)
+
+        self.assertEqual(actual.shape, (2, 4))
+        self.assertEqual(set(actual.ids(axis='sample')),
+                         set(['S1', 'S2', 'S3', 'S4']))
+        self.assertEqual(set(actual.ids(axis='observation')),
+                         set(['O1', 'O3']))
+        np.testing.assert_allclose(actual.sum(axis='sample'),
+                            np.array([1., 1., 1., 0.]))
+        np.testing.assert_allclose(actual.matrix_data.toarray(),
+                            np.array([[2/7, 5/9, 3/4, 0.],
+                                      [5/7, 4/9, 1/4, 0.]]))
 
 
 if __name__ == "__main__":

--- a/q2_feature_table/tests/filter/test_filter_features.py
+++ b/q2_feature_table/tests/filter/test_filter_features.py
@@ -253,11 +253,13 @@ class FilterFeaturesTests(unittest.TestCase):
                          set(['S1', 'S2', 'S3', 'S4']))
         self.assertEqual(set(actual.ids(axis='observation')),
                          set(['O1', 'O3']))
-        np.testing.assert_allclose(actual.sum(axis='sample'),
-                            np.array([1., 1., 1., 0.]))
-        np.testing.assert_allclose(actual.matrix_data.toarray(),
-                            np.array([[2/7, 5/9, 3/4, 0.],
-                                      [5/7, 4/9, 1/4, 0.]]))
+        np.testing.assert_allclose(
+            actual.sum(axis='sample'), np.array([1., 1., 1.,0.])
+        )
+        np.testing.assert_allclose(
+            actual.matrix_data.toarray(), np.array([[2/7, 5/9,3/4, 0.],
+                                                    [5/7, 4/9, 1/4, 0.]])
+        )
 
 
 if __name__ == "__main__":

--- a/q2_feature_table/tests/filter/test_filter_features.py
+++ b/q2_feature_table/tests/filter/test_filter_features.py
@@ -254,10 +254,10 @@ class FilterFeaturesTests(unittest.TestCase):
         self.assertEqual(set(actual.ids(axis='observation')),
                          set(['O1', 'O3']))
         np.testing.assert_allclose(
-            actual.sum(axis='sample'), np.array([1., 1., 1.,0.])
+            actual.sum(axis='sample'), np.array([1., 1., 1., 0.])
         )
         np.testing.assert_allclose(
-            actual.matrix_data.toarray(), np.array([[2/7, 5/9,3/4, 0.],
+            actual.matrix_data.toarray(), np.array([[2/7, 5/9, 3/4, 0.],
                                                     [5/7, 4/9, 1/4, 0.]])
         )
 


### PR DESCRIPTION
closes #359 

- add `FeatureTable[RelativeFrequency]` to the `filter-features` action
- `max-frequency` and `min-frequency` can only be used with `FeatureTable[Frequency]`
- `max-frequency` default was set to "inf" because of the `TypeMap` but behaviour is the same.
- the helper check_relative_frequency checks if all samples sum to 1 or 0 then it is classified as relative frequency.

This addition is needed to filter a `FeatureTable[RelativeFrequency]` with core-scores created with the new `core-score` action #358.

This PR was created in part with Codex 5.5
