### PR TITLE
TEST: selenium test updates

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -35,7 +35,7 @@ test:
   - q2templates >={{ q2templates }}
   - q2-types >={{ q2_types }}
   - pytest
-  - selenium
+  - selenium=4.44.0
   imports:
   - q2_feature_table
   - qiime2.plugins.feature_table

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -35,7 +35,7 @@ test:
   - q2templates >={{ q2templates }}
   - q2-types >={{ q2_types }}
   - pytest
-  - selenium=4.43.0
+  - selenium=4.44.0
   imports:
   - q2_feature_table
   - qiime2.plugins.feature_table

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -35,7 +35,7 @@ test:
   - q2templates >={{ q2templates }}
   - q2-types >={{ q2_types }}
   - pytest
-  - selenium=4.44.0
+  - selenium=4.43.0
   imports:
   - q2_feature_table
   - qiime2.plugins.feature_table

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -35,7 +35,10 @@ test:
   - q2templates >={{ q2templates }}
   - q2-types >={{ q2_types }}
   - pytest
-  - selenium=4.44.0
+  # pinning at 4.43.0 temporarily because a bug was introduced in 4.44.0
+  # that was causing test failures in summarize
+  # issue XREF: https://github.com/SeleniumHQ/selenium/issues/17448
+  - selenium=4.43.0
   imports:
   - q2_feature_table
   - qiime2.plugins.feature_table

--- a/q2_feature_table/tests/test_summarize.py
+++ b/q2_feature_table/tests/test_summarize.py
@@ -666,7 +666,7 @@ class _SummarizeTests(TestCase):
 
             # None should have danger to begin
             for element in element_list:
-                self.assertNotIn('danger', element.get_attribute('class'))
+                self.assertNotIn('danger', element.get_dom_attribute('class'))
 
             # This is not setting the value in the box, it is sending these key
             # presses to the box. There is already a 0 in the box, so we are

--- a/q2_feature_table/tests/test_summarize.py
+++ b/q2_feature_table/tests/test_summarize.py
@@ -12,7 +12,6 @@ import tempfile
 import re
 import json
 import csv
-import pytest
 
 import skbio
 import biom

--- a/q2_feature_table/tests/test_summarize.py
+++ b/q2_feature_table/tests/test_summarize.py
@@ -43,10 +43,10 @@ from q2_feature_table._summarize._vega_spec import vega_spec
 # A. None of the tests are run within a container, or
 # B. The chrome & firefox tests on mac will fill in enough gaps
 # that we can see if something goes wrong that is interesting.
-skip_selenium = pytest.mark.skipif(
-    os.getenv('SKIP_SELENIUM', '') == '1',
-    reason='skipping Selenium tests within linux container'
-    )
+# skip_selenium = pytest.mark.skipif(
+#     os.getenv('SKIP_SELENIUM', '') == '1',
+#     reason='skipping Selenium tests within linux container'
+#     )
 
 
 class TabulateSeqsTests(TestCase):
@@ -623,7 +623,7 @@ class _SummarizeTests(TestCase):
 
         self.assertEqual(spec['data'][0]['values'], exp)
 
-    @skip_selenium
+    # @skip_selenium
     def test_summarize_viz_chrome(self):
         chrome_options = ChromeOptions()
         chrome_options.add_argument("-headless")
@@ -631,7 +631,7 @@ class _SummarizeTests(TestCase):
         with webdriver.Chrome(options=chrome_options) as driver:
             self._selenium_test(driver)
 
-    @skip_selenium
+    # @skip_selenium
     def test_summarize_viz_firefox(self):
         firefox_options = FirefoxOptions()
         firefox_options.add_argument("-headless")

--- a/q2_feature_table/tests/test_summarize.py
+++ b/q2_feature_table/tests/test_summarize.py
@@ -36,18 +36,6 @@ from q2_feature_table._summarize._visualizer import _compute_descriptive_stats
 from q2_feature_table._summarize._visualizer import _frequencies
 from q2_feature_table._summarize._vega_spec import vega_spec
 
-# This is a temporary 'fix' to failing selenium tests when they are run
-# within a container on the GHA linux runner.
-# The failures aren't interesting and the hope is that this will either be
-# fixed such that:
-# A. None of the tests are run within a container, or
-# B. The chrome & firefox tests on mac will fill in enough gaps
-# that we can see if something goes wrong that is interesting.
-# skip_selenium = pytest.mark.skipif(
-#     os.getenv('SKIP_SELENIUM', '') == '1',
-#     reason='skipping Selenium tests within linux container'
-#     )
-
 
 class TabulateSeqsTests(TestCase):
 
@@ -623,7 +611,6 @@ class _SummarizeTests(TestCase):
 
         self.assertEqual(spec['data'][0]['values'], exp)
 
-    # @skip_selenium
     def test_summarize_viz_chrome(self):
         chrome_options = ChromeOptions()
         chrome_options.add_argument("-headless")
@@ -631,7 +618,6 @@ class _SummarizeTests(TestCase):
         with webdriver.Chrome(options=chrome_options) as driver:
             self._selenium_test(driver)
 
-    # @skip_selenium
     def test_summarize_viz_firefox(self):
         firefox_options = FirefoxOptions()
         firefox_options.add_argument("-headless")
@@ -666,7 +652,7 @@ class _SummarizeTests(TestCase):
 
             # None should have danger to begin
             for element in element_list:
-                self.assertNotIn('danger', element.get_dom_attribute('class'))
+                self.assertNotIn('danger', element.get_attribute('class'))
 
             # This is not setting the value in the box, it is sending these key
             # presses to the box. There is already a 0 in the box, so we are


### PR DESCRIPTION
<!-- PR guidance and examples: https://github.com/rachis-org/governance/blob/main/pr_template_guidelines.md -->
<!-- rachis Generative AI Policy: https://github.com/rachis-org/governance/blob/main/ai_policy.md -->

# Description
<!-- REQUIRED: Briefly describe this PR, or link the issue it closes. -->
This PR does two things:
- Removes some stale pytest fixtures to skip selenium tests on ubuntu. These are no longer needed because tests aren't being run inside a container on the github runner.
- Pins selenium at 4.43.0 to workaround a bug that was introduced in 4.44.0. [issue xref](https://github.com/SeleniumHQ/selenium/issues/17448).

# AI Disclosure
<!-- REQUIRED: Check exactly one option. -->

- [x] NO AI USED.
- [ ] AI USED.
